### PR TITLE
feat(ptinput): support point array/map round-trip in pipeline scripts

### DIFF
--- a/pkg/arbiter/builtin-funcs/docs/function_doc.md
+++ b/pkg/arbiter/builtin-funcs/docs/function_doc.md
@@ -1829,7 +1829,7 @@ Function parameters:
 - `status`: Event status. One of: (`critical`, `high`, `medium`, `low`, `info`).
 - `dimension_tags`: Dimension tags.
 - `related_data`: Related data.
-- `check_workspace_uuid`: UUID of the workspace related to the detection result
+- `check_workspace_uuid`: UUID of the workspace related to the detection result.
 
 
 Function examples:

--- a/pkg/arbiter/builtin-funcs/docs/function_doc.zh.md
+++ b/pkg/arbiter/builtin-funcs/docs/function_doc.zh.md
@@ -1829,7 +1829,7 @@
 - `status`: Event status. One of: (`critical`, `high`, `medium`, `low`, `info`).
 - `dimension_tags`: Dimension tags.
 - `related_data`: Related data.
-- `check_workspace_uuid`: UUID of the workspace related to the detection result
+- `check_workspace_uuid`: UUID of the workspace related to the detection result.
 
 
 函数示例：

--- a/ptinput/funcs/fn_addkey_test.go
+++ b/ptinput/funcs/fn_addkey_test.go
@@ -99,6 +99,24 @@ add_key(add_new_key, "shanghai")
 			expect: nil,
 			fail:   false,
 		},
+		{
+			name: "value type: list compatibility",
+			in:   `test`,
+			pl: `
+		add_key(add_new_key, [1, 2])
+		`,
+			expect: "[1,2]",
+			fail:   false,
+		},
+		{
+			name: "value type: map compatibility",
+			in:   `test`,
+			pl: `
+		add_key(add_new_key, {"a": 1, "b": "x"})
+		`,
+			expect: `{"a":1,"b":"x"}`,
+			fail:   false,
+		},
 	}
 
 	for idx, tc := range cases {

--- a/ptinput/funcs/fn_append_test.go
+++ b/ptinput/funcs/fn_append_test.go
@@ -77,6 +77,15 @@ func TestAppend(t *testing.T) {
 			expected: "[1,2]",
 			outkey:   "arr",
 		},
+		{
+			name: "append on point array via pt_kvs_get",
+			pl: `a = pt_kvs_get("nums")
+			b = append(a, 3)
+			pt_kvs_set("arr", b)`,
+			in:       `test`,
+			expected: "[1,2,3]",
+			outkey:   "arr",
+		},
 	}
 
 	for idx, tc := range cases {
@@ -90,8 +99,19 @@ func TestAppend(t *testing.T) {
 				}
 				return
 			}
-			pt := ptinput.NewPlPt(
-				point.Logging, "test", nil, map[string]any{"message": tc.in}, time.Now())
+			var pt ptinput.PlInputPt
+			if tc.name == "append on point array via pt_kvs_get" {
+				raw := point.NewPoint("test",
+					point.KVs{
+						point.NewKV("message", tc.in),
+						point.NewKV("nums", []int{1, 2}),
+					},
+					point.DefaultLoggingOptions()...)
+				pt = ptinput.PtWrap(point.Logging, raw)
+			} else {
+				pt = ptinput.NewPlPt(
+					point.Logging, "test", nil, map[string]any{"message": tc.in}, time.Now())
+			}
 			errR := runScript(runner, pt)
 			if errR != nil {
 				t.Fatal(*errR)

--- a/ptinput/funcs/fn_len_test.go
+++ b/ptinput/funcs/fn_len_test.go
@@ -45,6 +45,14 @@ func TestLen(t *testing.T) {
 			expected: int64(4),
 			outkey:   "abc",
 		},
+		{
+			name: "len point array via pt_kvs_get",
+			pl: `abc = pt_kvs_get("nums")
+			add_key(abc, len(abc))`,
+			in:       `test`,
+			expected: int64(3),
+			outkey:   "abc",
+		},
 	}
 
 	for idx, tc := range cases {
@@ -58,8 +66,19 @@ func TestLen(t *testing.T) {
 				}
 				return
 			}
-			pt := ptinput.NewPlPt(
-				point.Logging, "test", nil, map[string]any{"message": tc.in}, time.Now())
+			var pt ptinput.PlInputPt
+			if tc.name == "len point array via pt_kvs_get" {
+				raw := point.NewPoint("test",
+					point.KVs{
+						point.NewKV("message", tc.in),
+						point.NewKV("nums", []int{1, 2, 3}),
+					},
+					point.DefaultLoggingOptions()...)
+				pt = ptinput.PtWrap(point.Logging, raw)
+			} else {
+				pt = ptinput.NewPlPt(
+					point.Logging, "test", nil, map[string]any{"message": tc.in}, time.Now())
+			}
 			errR := runScript(runner, pt)
 
 			if errR != nil {

--- a/ptinput/funcs/fn_pt_kvs.go
+++ b/ptinput/funcs/fn_pt_kvs.go
@@ -164,7 +164,7 @@ var (
 )
 
 func ptKvsGet(ctx *runtime.Task, funcExpr *ast.CallExpr, vals ...any) *errchain.PlError {
-	if val, dtype, err := getPtKey(ctx.InData(), vals[0].(string)); err != nil {
+	if val, dtype, err := getPtKeyRaw(ctx.InData(), vals[0].(string)); err != nil {
 		ctx.Regs.ReturnAppend(nil, ast.Nil)
 	} else {
 		ctx.Regs.ReturnAppend(val, dtype)

--- a/ptinput/funcs/fn_pt_kvs_integration_test.go
+++ b/ptinput/funcs/fn_pt_kvs_integration_test.go
@@ -1,0 +1,134 @@
+package funcs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GuanceCloud/cliutils/point"
+	"github.com/GuanceCloud/pipeline-go/ptinput"
+	"github.com/GuanceCloud/platypus/pkg/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPtKvsGetInOperator(t *testing.T) {
+	pl := `
+	arr = pt_kvs_get("nums")
+	if 2 in arr {
+		pt_kvs_set("hit", true)
+	}
+	`
+
+	runner, err := NewTestingRunner(pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw := point.NewPoint("test",
+		point.KVs{
+			point.NewKV("message", "test"),
+			point.NewKV("nums", []int{1, 2, 3}),
+		},
+		point.DefaultLoggingOptions()...)
+	pt := ptinput.PtWrap(point.Logging, raw)
+
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	v, _, err := pt.Get("hit")
+	assert.NoError(t, err)
+	assert.Equal(t, true, v)
+}
+
+func TestPtKvsGetAppendLenChain(t *testing.T) {
+	pl := `
+	arr = pt_kvs_get("nums")
+	arr = append(arr, 4)
+	pt_kvs_set("size", len(arr))
+	pt_kvs_set("arr", arr)
+	`
+
+	runner, err := NewTestingRunner(pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw := point.NewPoint("test",
+		point.KVs{
+			point.NewKV("message", "test"),
+			point.NewKV("nums", []int{1, 2, 3}),
+		},
+		append(point.DefaultLoggingOptions(), point.WithTime(time.Now()))...,
+	)
+	pt := ptinput.PtWrap(point.Logging, raw)
+
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	v, _, err := pt.Get("size")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), v)
+
+	v, _, err = pt.Get("arr")
+	assert.NoError(t, err)
+	assert.Equal(t, "[1,2,3,4]", v)
+
+	v, dt, err := pt.GetRaw("arr")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.List, dt)
+	assert.Equal(t, []any{int64(1), int64(2), int64(3), int64(4)}, v)
+}
+
+func TestPtKvsSetMap(t *testing.T) {
+	pl := `
+	obj = {"a": 1, "b": "x"}
+	pt_kvs_set("obj", obj)
+	`
+
+	runner, err := NewTestingRunner(pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{"message": "test"}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	v, dt, err := pt.GetRaw("obj")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.Map, dt)
+	assert.Equal(t, map[string]any{"a": int64(1), "b": "x"}, v)
+
+	v, dt, err = pt.Get("obj")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.String, dt)
+	assert.Equal(t, `{"a":1,"b":"x"}`, v)
+}
+
+func TestPtKvsGetMapCompatibility(t *testing.T) {
+	pl := `
+	obj = {"a": 1, "b": "x"}
+	pt_kvs_set("obj", obj)
+	add_key("obj_type", value_type(pt_kvs_get("obj")))
+	`
+
+	runner, err := NewTestingRunner(pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{"message": "test"}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	v, _, err := pt.Get("obj_type")
+	assert.NoError(t, err)
+	assert.Equal(t, "map", v)
+}

--- a/ptinput/funcs/fn_pt_kvs_test.go
+++ b/ptinput/funcs/fn_pt_kvs_test.go
@@ -257,3 +257,50 @@ func TestPtKvsSet(t *testing.T) {
 		})
 	}
 }
+
+func TestPtKvsGetComposite(t *testing.T) {
+	funcs := []*Function{
+		FnPtKvsGet,
+		FnPtKvsSet,
+	}
+
+	cases := []struct {
+		name   string
+		kvs    point.KVs
+		pl     string
+		key    string
+		expect any
+	}{
+		{
+			name: "list",
+			kvs: point.KVs{
+				point.NewKV("key1", []int{1, 2}),
+			},
+			pl: `
+			pt_kvs_set("key2", pt_kvs_get("key1"))
+			`,
+			key:    "key2",
+			expect: `[1,2]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			script, err := parseScipt(tc.pl, funcs)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			raw := point.NewPoint("test", tc.kvs, point.DefaultLoggingOptions()...)
+			pt := ptinput.PtWrap(point.Logging, raw)
+			errR := script.Run(pt, nil)
+			if errR != nil {
+				t.Fatal(errR.Error())
+			}
+
+			v, _, err := pt.Get(tc.key)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expect, v)
+		})
+	}
+}

--- a/ptinput/funcs/fn_set_tag_test.go
+++ b/ptinput/funcs/fn_set_tag_test.go
@@ -85,6 +85,28 @@ func TestSetTag(t *testing.T) {
 			expect: "3",
 			fail:   false,
 		},
+		{
+			name: "set_tag list stringify",
+			in:   `test`,
+			pl: `
+			a = [1, 2]
+			set_tag("arr_tag", a)
+	`,
+			outtag: "arr_tag",
+			expect: "[1,2]",
+			fail:   false,
+		},
+		{
+			name: "set_tag map stringify",
+			in:   `test`,
+			pl: `
+			a = {"a": 1, "b": "x"}
+			set_tag("obj_tag", a)
+	`,
+			outtag: "obj_tag",
+			expect: `{"a":1,"b":"x"}`,
+			fail:   false,
+		},
 	}
 
 	for idx, tc := range cases {

--- a/ptinput/funcs/md/pt_kvs_get.en.md
+++ b/ptinput/funcs/md/pt_kvs_get.en.md
@@ -4,6 +4,12 @@ Function prototype: `fn pt_kvs_get(name: str) -> any`
 
 Function description: Return the value of the specified key in Point
 
+Notes:
+
+- If the field stored in Point is an array or map, the return value is preserved as `list` / `map`, so it can be used by script operations such as `append()`, `len()`, and `in`
+- Tags are always returned as strings
+- If the value was already stored as a JSON string earlier in the pipeline, the returned value is still a string
+
 Function parameters:
 
 - `name`: Key name
@@ -12,4 +18,8 @@ Example:
 
 ```python
 host = pt_kvs_get("host")
+
+nums = pt_kvs_get("nums")
+nums = append(nums, 4)
+pt_kvs_set("nums", nums)
 ```

--- a/ptinput/funcs/md/pt_kvs_get.md
+++ b/ptinput/funcs/md/pt_kvs_get.md
@@ -4,6 +4,12 @@
 
 函数说明：返回 Point 中指定 key 的值
 
+说明：
+
+- 当 Point 中的字段是数组或字典时，返回值会保留为 `list` / `map`，可继续参与 `append()`、`len()`、`in` 等脚本运算
+- tag 始终按字符串返回
+- 如果该值已在更早的处理链路中被存成 JSON 字符串，则返回的仍然是字符串
+
 函数参数：
 
 - `name`: Key 名
@@ -12,4 +18,8 @@
 
 ```python
 host = pt_kvs_get("host")
+
+nums = pt_kvs_get("nums")
+nums = append(nums, 4)
+pt_kvs_set("nums", nums)
 ```

--- a/ptinput/funcs/md/pt_kvs_set.en.md
+++ b/ptinput/funcs/md/pt_kvs_set.en.md
@@ -4,6 +4,12 @@ Function prototype: `fn pt_kvs_set(name: str, value: any, as_tag: bool = false) 
 
 Function description: Add a key to a Point or modify the value of a key in a Point
 
+Notes:
+
+- When setting a field, `list` values are preserved as native Point array fields whenever possible
+- When setting a field, `map` values are preserved as native Point dict fields whenever possible
+- When setting a tag, the value is converted to a string
+
 Function parameters:
 
 - `name`: The name of the field or label to be added or modified
@@ -21,4 +27,8 @@ kvs = {
 for k in kvs {
     pt_kvs_set(k, kvs[k])
 }
+
+nums = pt_kvs_get("nums")
+nums = append(nums, 4)
+pt_kvs_set("nums", nums)
 ```

--- a/ptinput/funcs/md/pt_kvs_set.md
+++ b/ptinput/funcs/md/pt_kvs_set.md
@@ -4,6 +4,12 @@
 
 函数说明：往 Point 中添加 key 或修改 Point 中 key 的值
 
+说明：
+
+- 设置 field 时，`list` 会优先保留为 Point 原生数组字段
+- 设置 field 时，`map` 会优先保留为 Point 原生字典字段
+- 设置 tag 时，值会转换为字符串
+
 函数参数：
 
 - `name`: 待添加或修改的字段或标签的名
@@ -21,4 +27,8 @@ kvs = {
 for k in kvs {
     pt_kvs_set(k, kvs[k])
 }
+
+nums = pt_kvs_get("nums")
+nums = append(nums, 4)
+pt_kvs_set("nums", nums)
 ```

--- a/ptinput/funcs/utils.go
+++ b/ptinput/funcs/utils.go
@@ -203,6 +203,18 @@ func getPtKey(in any, key string) (any, ast.DType, error) {
 	return pt.Get(key)
 }
 
+func getPtKeyRaw(in any, key string) (any, ast.DType, error) {
+	pt, err := getPoint(in)
+	if err != nil {
+		return nil, ast.Invalid, err
+	}
+
+	if key == "_" {
+		key = ptinput.Originkey
+	}
+	return pt.GetRaw(key)
+}
+
 func deletePtKey(in any, key string) {
 	pt, err := getPoint(in)
 	if err != nil {

--- a/ptinput/point.go
+++ b/ptinput/point.go
@@ -23,6 +23,99 @@ import (
 	"github.com/spf13/cast"
 )
 
+func normalizeListValue(v any) ([]any, bool) {
+	switch arr := v.(type) {
+	case []any:
+		return arr, true
+	case []int:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []int8:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []int16:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []int32:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []int64:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = x
+		}
+		return res, true
+	case []uint:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []uint16:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []uint32:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []uint64:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = int64(x)
+		}
+		return res, true
+	case []float32:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = float64(x)
+		}
+		return res, true
+	case []float64:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = x
+		}
+		return res, true
+	case []string:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = x
+		}
+		return res, true
+	case []bool:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = x
+		}
+		return res, true
+	case [][]byte:
+		res := make([]any, len(arr))
+		for i, x := range arr {
+			res[i] = string(x)
+		}
+		return res, true
+	default:
+		return nil, false
+	}
+}
+
 type (
 	KeyKind uint
 	PtFlag  uint
@@ -35,6 +128,7 @@ type PlInputPt interface {
 	SetPtName(m string)
 
 	Get(key string) (any, ast.DType, error)
+	GetRaw(key string) (any, ast.DType, error)
 	Set(key string, value any, dtype ast.DType) bool
 
 	Delete(key string)
@@ -159,6 +253,10 @@ func NewPlPoint(category point.Category, name string,
 }
 
 func valueDtype(v any) (any, ast.DType) {
+	return valueDtypeComposite(v, false)
+}
+
+func valueDtypeComposite(v any, allowComposite bool) (any, ast.DType) {
 	switch v := v.(type) {
 	case int32, int8, int16, int,
 		uint, uint16, uint32, uint64, uint8:
@@ -175,6 +273,24 @@ func valueDtype(v any) (any, ast.DType) {
 		return string(v), ast.String
 	case string:
 		return v, ast.String
+	case map[string]any:
+		if allowComposite {
+			return v, ast.Map
+		}
+		if s, err := Conv2String(v, ast.Map); err == nil {
+			return s, ast.String
+		}
+		return nil, ast.Nil
+	}
+
+	if arr, ok := normalizeListValue(v); ok {
+		if allowComposite {
+			return arr, ast.List
+		}
+		if s, err := Conv2String(arr, ast.List); err == nil {
+			return s, ast.String
+		}
+		return nil, ast.Nil
 	}
 
 	// ignore unknown type
@@ -212,12 +328,20 @@ func (pt *PlPoint) Category() point.Category {
 var ErrKeyNotExist = errors.New("key not exist")
 
 func (pt *PlPoint) Get(key string) (any, ast.DType, error) {
+	return pt.get(key, false)
+}
+
+func (pt *PlPoint) GetRaw(key string) (any, ast.DType, error) {
+	return pt.get(key, true)
+}
+
+func (pt *PlPoint) get(key string, allowComposite bool) (any, ast.DType, error) {
 	if v, ok := pt.tags[key]; ok {
 		return v, ast.String, nil
 	}
 
 	if v, ok := pt.fields[key]; ok {
-		v, dtype := valueDtype(v)
+		v, dtype := valueDtypeComposite(v, allowComposite)
 		return v, dtype, nil
 	}
 	return nil, ast.Nil, ErrKeyNotExist

--- a/ptinput/point_test.go
+++ b/ptinput/point_test.go
@@ -115,3 +115,22 @@ func TestPt(t *testing.T) {
 		t.Fatal("name != \"t2\"")
 	}
 }
+
+func TestPlPointGetRawComposite(t *testing.T) {
+	pt := NewPlPoint(point.Logging, "t", nil, map[string]any{
+		"arr": []any{int64(1), "x"},
+	}, time.Now())
+
+	v, dt, err := pt.GetRaw("arr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dt != ast.List {
+		t.Fatalf("unexpected dtype: %s", dt.String())
+	}
+
+	if got, ok := v.([]any); !ok || len(got) != 2 || got[0] != int64(1) || got[1] != "x" {
+		t.Fatalf("unexpected value: %#v", v)
+	}
+}

--- a/ptinput/pt.go
+++ b/ptinput/pt.go
@@ -7,6 +7,7 @@ package ptinput
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/GuanceCloud/cliutils/point"
@@ -20,6 +21,59 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/spf13/cast"
 )
+
+var pointCompositeMu sync.Mutex
+
+func pointAnyRaw(x any) (any, error) {
+	pointCompositeMu.Lock()
+	defer pointCompositeMu.Unlock()
+
+	anyVal, ok := x.(*point.Field_A)
+	if !ok {
+		return nil, fmt.Errorf("unexpected composite field type %T", x)
+	}
+
+	old := point.EnableDictField
+	point.EnableDictField = true
+	defer func() { point.EnableDictField = old }()
+
+	return point.AnyRaw(anyVal.A)
+}
+
+func normalizePointMapValue(v map[string]any) (any, bool) {
+	pointCompositeMu.Lock()
+	defer pointCompositeMu.Unlock()
+
+	old := point.EnableDictField
+	point.EnableDictField = true
+	defer func() { point.EnableDictField = old }()
+
+	dict, err := point.NewMap(v)
+	if err != nil {
+		return nil, false
+	}
+	anyVal, err := point.NewAny(dict)
+	if err != nil {
+		return nil, false
+	}
+	return anyVal, true
+}
+
+func normalizePointFieldValue(v any) (any, bool) {
+	switch x := v.(type) {
+	case map[string]any:
+		return normalizePointMapValue(x)
+	default:
+		if arr, ok := normalizeListValue(v); ok {
+			anyVal, err := point.NewAnyArray(arr...)
+			if err != nil {
+				return nil, false
+			}
+			return anyVal, true
+		}
+		return nil, false
+	}
+}
 
 type Pt struct {
 	pt       *point.Point
@@ -59,11 +113,19 @@ func (pp *Pt) SetPtName(name string) {
 }
 
 func (pp *Pt) Get(k string) (any, ast.DType, error) {
+	return pp.get(k, false)
+}
+
+func (pp *Pt) GetRaw(k string) (any, ast.DType, error) {
+	return pp.get(k, true)
+}
+
+func (pp *Pt) get(k string, allowComposite bool) (any, ast.DType, error) {
 	kv := pp.pt.KVs().Get(k)
 	if kv == nil {
 		return nil, ast.Nil, ErrKeyNotExist
 	}
-	v1, v2 := getVal(kv, false)
+	v1, v2 := getVal(kv, allowComposite)
 	return v1, v2, nil
 }
 
@@ -84,7 +146,13 @@ func (pp *Pt) _set(k string, v any, asTag bool, asField bool) {
 		asTag = true
 	}
 
-	v, _ = normalVal(v, asTag, false)
+	if asTag {
+		v, _ = normalVal(v, true, false)
+	} else if normalized, ok := normalizePointFieldValue(v); ok {
+		v = normalized
+	} else {
+		v, _ = normalVal(v, false, false)
+	}
 
 	pp.pt.MustAddKVs(point.NewKV(k, v, point.WithKVTagSet(asTag)))
 }
@@ -203,17 +271,19 @@ func getVal(kv *point.Field, allowComposite bool) (any, ast.DType) {
 		return kv.GetS(), ast.String
 
 	case *point.Field_A:
-		v, err := point.AnyRaw(kv.GetA())
+		v, err := pointAnyRaw(kv.Val)
 		if err != nil {
 			return nil, ast.Nil
 		}
 		switch v.(type) {
-		case []any:
-			val, dt = v, ast.List
 		case map[string]any:
 			val, dt = v, ast.Map
 		default:
-			return nil, ast.Nil
+			if arr, ok := normalizeListValue(v); ok {
+				val, dt = arr, ast.List
+			} else {
+				return nil, ast.Nil
+			}
 		}
 	default:
 		return nil, ast.Nil
@@ -249,14 +319,16 @@ func normalVal(v any, conv2Str bool, allowComposite bool) (any, ast.DType) {
 		val, dt = cast.ToFloat64(v), ast.Float
 	case bool:
 		val, dt = v, ast.Bool
-	case []any:
-		val, dt = v, ast.List
 	case map[string]any:
 		val, dt = v, ast.Map
 	case []byte:
 		val, dt = string(v), ast.String
 	default:
-		val, dt = nil, ast.Nil
+		if arr, ok := normalizeListValue(v); ok {
+			val, dt = arr, ast.List
+		} else {
+			val, dt = nil, ast.Nil
+		}
 	}
 
 	if conv2Str {

--- a/ptinput/pt_test.go
+++ b/ptinput/pt_test.go
@@ -174,6 +174,58 @@ func TestPlPt2(t *testing.T) {
 	}
 }
 
+func TestPtGetRawComposite(t *testing.T) {
+	raw := point.NewPoint("t",
+		point.KVs{
+			point.NewKV("arr", []int{1, 2}),
+		},
+		point.DefaultLoggingOptions()...)
+	pt := PtWrap(point.Logging, raw)
+
+	v, dt, err := pt.GetRaw("arr")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.List, dt)
+	assert.Equal(t, []any{int64(1), int64(2)}, v)
+
+	v, dt, err = pt.Get("arr")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.String, dt)
+	assert.Equal(t, `[1,2]`, v)
+}
+
+func TestPtSetPreserveComposite(t *testing.T) {
+	pt := NewPlPt(point.Logging, "t", nil, nil, time.Now())
+
+	ok := pt.Set("arr", []any{int64(1), int64(2)}, ast.List)
+	assert.True(t, ok)
+
+	v, dt, err := pt.GetRaw("arr")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.List, dt)
+	assert.Equal(t, []any{int64(1), int64(2)}, v)
+
+	raw := pt.Point().KVs().Get("arr")
+	assert.NotNil(t, raw)
+	assert.Equal(t, []int64{1, 2}, raw.Raw())
+}
+
+func TestPtSetPreserveMap(t *testing.T) {
+	pt := NewPlPt(point.Logging, "t", nil, nil, time.Now())
+
+	ok := pt.Set("obj", map[string]any{"a": int64(1), "b": "x"}, ast.Map)
+	assert.True(t, ok)
+
+	v, dt, err := pt.GetRaw("obj")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.Map, dt)
+	assert.Equal(t, map[string]any{"a": int64(1), "b": "x"}, v)
+
+	v, dt, err = pt.Get("obj")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.String, dt)
+	assert.Equal(t, `{"a":1,"b":"x"}`, v)
+}
+
 var lp = []byte(`gin app="deployment-forethought-kodo-kodo",client_ip="172.1***03",cluster_name_k8s="k8s-daily",container_id="dcbacc667c1534127d4f4c531fc26f613f4e6f822e646dee4e4bdbc5e87920c4",container_name="kodo",deployment="kodo",filepath="/rootfs/var/log/pods/forethought-kodo_kodo-7dc8b5c448-rmcpb_bd5159c7-df57-4346-987d-fc6883aeabea/kodo/0.log",test_site="daily",host="cluster_a_cn-hangzhou.172.1***.102",host_ip="172.1***.102",image="registry.****.com/ko**:testing-202*****",log_read_lines=289892,message="[GIN] 2024/11/15 - 10:56:07 | 403 | 759.859µs |  172.16.200.203 | POST    \"/v1/write/metric?token=****************842cda605c6cb87e3a7b8\"",message_length=137,namespace="forethought-kodo",pod-template-hash="7dc8b5c448",pod_ip="10.113.0.204",pod_name="kodo-7dc8b5c448-rmcpb",real_host="hz--daily-002",region="cn-hangzhou",service="kodo",status="warning",time_ns=1731639367526632400,time_us=1731639367526632,timestamp="2024/11/15 - 10:56:07",zone_id="cn-hangzhou-j" 1731639367526000000`)
 
 func BenchmarkPts(b *testing.B) {


### PR DESCRIPTION
- add GetRaw to preserve composite values from point fields
- make pt_kvs_get return native list/map for point composite fields
- preserve list/map when writing back to point fields
- keep Get/add_key/set_tag compatibility by returning stringified values
- add regression tests for append/len/in and map compatibility
- update pt_kvs_get/pt_kvs_set docs