### PR TITLE
test arbiter runtime signal propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.1
 	github.com/GuanceCloud/cliutils v1.1.22-0.20260326081525-39733a0223bf
 	github.com/GuanceCloud/grok v1.1.5-0.20260513103143-a1797907b1d0
-	github.com/GuanceCloud/platypus v0.3.4
+	github.com/GuanceCloud/platypus v0.3.5-0.20260529080946-6085d331d151
 	github.com/antchfx/xmlquery v1.3.18
 	github.com/araddon/dateparse v0.0.0-20201001162425-8aadafed4dc4
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/GuanceCloud/influxdb1-client v0.1.8 h1:7XNICWcW+NxAHFkzQ8mkOCKA/8U2WN
 github.com/GuanceCloud/influxdb1-client v0.1.8/go.mod h1:4HC4b/O653/ezBiHMPBnHYnHCCfsNT2LvCr7wNLngw4=
 github.com/GuanceCloud/platypus v0.3.4 h1:eukTGJbnzNi2pvWZ0Qo0bxmLctv8HUbZYejZSQK7jNM=
 github.com/GuanceCloud/platypus v0.3.4/go.mod h1:H9Sol/SI+A9ppJUohdn9m/UA0aiNvh+G0/GnY6IVDnI=
+github.com/GuanceCloud/platypus v0.3.5-0.20260529080946-6085d331d151 h1:tdqFZIXm0nHHjzJ8G0zyPS4PJBC5FhvFn9i0szmOufM=
+github.com/GuanceCloud/platypus v0.3.5-0.20260529080946-6085d331d151/go.mod h1:H9Sol/SI+A9ppJUohdn9m/UA0aiNvh+G0/GnY6IVDnI=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=

--- a/pkg/arbiter/siem_test.go
+++ b/pkg/arbiter/siem_test.go
@@ -1,0 +1,38 @@
+package arbiter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type contextExitSignal struct {
+	ctx context.Context
+}
+
+func (s contextExitSignal) ExitSignal() bool {
+	return s.ctx != nil && s.ctx.Err() != nil
+}
+
+func TestRunStopsWhenSignalExits(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		errCh <- Run("test.p", `for ;; {}`, func(c *Config) {
+			c.Signal = contextExitSignal{ctx: ctx}
+		})
+	}()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+		require.Less(t, time.Since(start), time.Second)
+	case <-time.After(time.Second):
+		t.Fatal("arbiter runtime did not stop after signal exit")
+	}
+}


### PR DESCRIPTION
## What changed

- Bump `github.com/GuanceCloud/platypus` to the main commit that fixes `runtimev2` signal propagation.
- Add an arbiter-level regression test proving `arbiter.Run` can stop a pure script loop when the runtime signal exits.

## Why

The arbiter passes `cfg.Signal` down into `runtimev2.Script.Run`, but before GuanceCloud/platypus#67 the runtime ignored that signal. This PR pins pipeline-go to the fixed platypus commit and covers the pipeline-go arbiter integration path so the behavior does not regress.

## Validation

- `go test -count=3 ./pkg/arbiter ./pkg/arbiter/builtin-funcs ./pkg/arbiter/dql`

Note: `go test -count=1 ./pkg/arbiter/request` still has existing host filter failures in this environment (`test4`/`test5`), unrelated to this PR.