### PR TITLE
[codex] Add grok run observer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.1
 	github.com/GuanceCloud/cliutils v1.1.22-0.20260326081525-39733a0223bf
-	github.com/GuanceCloud/grok v1.1.5-0.20260513103143-a1797907b1d0
+	github.com/GuanceCloud/grok v1.1.5-0.20260603093938-df62b49f2f01
 	github.com/GuanceCloud/platypus v0.3.5-0.20260529080946-6085d331d151
 	github.com/antchfx/xmlquery v1.3.18
 	github.com/araddon/dateparse v0.0.0-20201001162425-8aadafed4dc4

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,10 @@ github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5Tl
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/GuanceCloud/cliutils v1.1.22-0.20260326081525-39733a0223bf h1:jv3sbJVjOB/YYeqMUg7tsBBL2zTlovGLLtIMnzar+lo=
 github.com/GuanceCloud/cliutils v1.1.22-0.20260326081525-39733a0223bf/go.mod h1:srJuHkdED/YhjaIayQUJhmPBkmmVPzUX0hsbdIhYd5g=
-github.com/GuanceCloud/grok v1.1.5-0.20260513103143-a1797907b1d0 h1:WXSg/50AX0l0RBvzoIEBjm49FyNsMihjS2nohApROes=
-github.com/GuanceCloud/grok v1.1.5-0.20260513103143-a1797907b1d0/go.mod h1:AeiXV1KQ6E62Xy5aC63TF+QhMcye8HvxCl/G/WFP6EM=
+github.com/GuanceCloud/grok v1.1.5-0.20260603093938-df62b49f2f01 h1:q7Ovi0kCCbZ5W3Svf8ram4KKH6ISt0VpkQpCYvJkAB8=
+github.com/GuanceCloud/grok v1.1.5-0.20260603093938-df62b49f2f01/go.mod h1:AeiXV1KQ6E62Xy5aC63TF+QhMcye8HvxCl/G/WFP6EM=
 github.com/GuanceCloud/influxdb1-client v0.1.8 h1:7XNICWcW+NxAHFkzQ8mkOCKA/8U2WNH5m+Hm9g0vz4k=
 github.com/GuanceCloud/influxdb1-client v0.1.8/go.mod h1:4HC4b/O653/ezBiHMPBnHYnHCCfsNT2LvCr7wNLngw4=
-github.com/GuanceCloud/platypus v0.3.4 h1:eukTGJbnzNi2pvWZ0Qo0bxmLctv8HUbZYejZSQK7jNM=
-github.com/GuanceCloud/platypus v0.3.4/go.mod h1:H9Sol/SI+A9ppJUohdn9m/UA0aiNvh+G0/GnY6IVDnI=
 github.com/GuanceCloud/platypus v0.3.5-0.20260529080946-6085d331d151 h1:tdqFZIXm0nHHjzJ8G0zyPS4PJBC5FhvFn9i0szmOufM=
 github.com/GuanceCloud/platypus v0.3.5-0.20260529080946-6085d331d151/go.mod h1:H9Sol/SI+A9ppJUohdn9m/UA0aiNvh+G0/GnY6IVDnI=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=

--- a/ptinput/funcs/fn_grok.go
+++ b/ptinput/funcs/fn_grok.go
@@ -7,6 +7,7 @@ package funcs
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/GuanceCloud/grok"
 	"github.com/GuanceCloud/pipeline-go/ptinput"
@@ -89,8 +90,21 @@ func Grok(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 		}
 	}
 
+	observer := currentGrokRunObserver()
+	var start time.Time
+	if observer != nil {
+		start = time.Now()
+	}
+
 	if grokRe.WithTypeInfo() {
-		result, err := grokRe.RunWithTypeInfo(val, trimSpace)
+		var result []any
+		if observer != nil {
+			var meta grok.RunMeta
+			result, err = grokRe.RunWithTypeInfoWithMeta(val, trimSpace, &meta)
+			observeGrokRun(observer, ctx.Name(), funcExpr.NamePos.Ln, funcExpr.NamePos.Col, meta, start)
+		} else {
+			result, err = grokRe.RunWithTypeInfo(val, trimSpace)
+		}
 		if err != nil {
 			ctx.Regs.ReturnAppend(false, ast.Bool)
 			return nil
@@ -119,7 +133,14 @@ func Grok(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 			}
 		}
 	} else {
-		result, err := grokRe.Run(val, trimSpace)
+		var result []string
+		if observer != nil {
+			var meta grok.RunMeta
+			result, err = grokRe.RunWithMeta(val, trimSpace, &meta)
+			observeGrokRun(observer, ctx.Name(), funcExpr.NamePos.Ln, funcExpr.NamePos.Col, meta, start)
+		} else {
+			result, err = grokRe.Run(val, trimSpace)
+		}
 		if err != nil {
 			ctx.Regs.ReturnAppend(false, ast.Bool)
 			return nil

--- a/ptinput/funcs/fn_grok_test.go
+++ b/ptinput/funcs/fn_grok_test.go
@@ -222,6 +222,53 @@ grok(_, "%{WORD:date} %{time}")`,
 	}
 }
 
+func TestGrokRunObserver(t *testing.T) {
+	events := make(chan GrokRunInfo, 1)
+	SetGrokRunObserver(func(info GrokRunInfo) {
+		events <- info
+	})
+	defer SetGrokRunObserver(nil)
+
+	runner, err := NewTestingRunner(`
+grok(_, "%{NOTSPACE:client_ip} %{NOTSPACE:http_ident} %{NOTSPACE:http_auth} \\[%{HTTPDATE:time}\\] \"%{DATA:http_method} %{GREEDYDATA:http_url} HTTP/%{NUMBER:http_version}\" %{INT:status_code} %{INT:bytes}")
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil,
+		map[string]any{"message": `127.0.0.1 - - [21/Jul/2021:14:14:38 +0800] "GET /?1 HTTP/1.1" 200 2178`},
+		time.Now())
+	if errR := runScript(runner, pt); errR != nil {
+		t.Fatal(errR)
+	}
+
+	select {
+	case info := <-events:
+		if info.ScriptName != "default.p" {
+			t.Fatalf("script name = %q", info.ScriptName)
+		}
+		if info.Line <= 0 || info.Column <= 0 {
+			t.Fatalf("expected positive source position, got line=%d column=%d", info.Line, info.Column)
+		}
+		if info.PatternHash == 0 {
+			t.Fatal("expected pattern hash")
+		}
+		if info.Path == "" {
+			t.Fatal("expected path")
+		}
+		if info.WorkUnits <= 0 {
+			t.Fatalf("expected positive work units, got %d", info.WorkUnits)
+		}
+		if info.Cost <= 0 {
+			t.Fatalf("expected positive cost, got %s", info.Cost)
+		}
+	default:
+		t.Fatal("expected grok observer event")
+	}
+}
+
 func TestGrokFastPathCompatibility(t *testing.T) {
 	cases := []struct {
 		name, pl, in string

--- a/ptinput/funcs/funcs_benchmark_test.go
+++ b/ptinput/funcs/funcs_benchmark_test.go
@@ -232,6 +232,71 @@ grok(_, "%{IPORHOST:client_ip} %{NOTSPACE:http_ident} %{NOTSPACE:http_auth} \\[%
 	}
 }
 
+const istioAccessLog = `[2026-06-02T23:51:30.123Z] "GET /api/v1/query?x=1 HTTP/1.1" 200 - via_upstream - "-" 0 1234 12 11 "10.1.1.1,10.2.2.2" "curl/8.0" "9b3c6f2a-1b90-4e4f-b7b0-8d1d5f1a0001" "example.com" "10.0.0.1:8080" outbound|8080||svc.ns.svc.cluster.local 10.10.0.1:443 10.10.0.2:8443 10.10.0.3:55555 - default`
+
+func BenchmarkGrokIstioAccessRiskPattern(b *testing.B) {
+	script := `
+grok(_, "\\[%{TIMESTAMP_ISO8601:start_time}\\] \"%{GREEDYDATA:http_method} %{GREEDYDATA:http_path} %{GREEDYDATA:protocol}\" %{GREEDYDATA:response_code} %{GREEDYDATA:response_flags} %{GREEDYDATA:response_code_details} %{GREEDYDATA:connection_termination_details} \"%{GREEDYDATA:upstream_transport_failure_reason}\" %{GREEDYDATA:bytes_received} %{GREEDYDATA:bytes_sent} %{GREEDYDATA:duration} %{GREEDYDATA:resp_upstream_service_time} \"%{GREEDYDATA:req_x_forwarded_for}\" \"%{GREEDYDATA:req_user_agent}\" \"%{GREEDYDATA:req_x_request_id}\" \"%{GREEDYDATA:req_authority}\" \"%{GREEDYDATA:upstream_host}\" %{GREEDYDATA:upstream_cluster} %{GREEDYDATA:upstream_local_address} %{GREEDYDATA:downstream_local_address} %{GREEDYDATA:downstream_remote_address} %{GREEDYDATA:requested_server_name} %{GREEDYDATA:route_name}")
+`
+	runner, err := NewTestingRunner(script)
+	if err != nil {
+		b.Fatal(err)
+	}
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": istioAccessLog}, time.Now())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if errR := runScript(runner, pt); errR != nil {
+			b.Fatal(errR)
+		}
+	}
+}
+
+func BenchmarkGrokIstioAccessTightPattern(b *testing.B) {
+	script := `
+grok(_, "^\\[%{TIMESTAMP_ISO8601:start_time}\\] \"%{WORD:http_method} %{DATA:http_path} %{NOTSPACE:protocol}\" %{INT:response_code:int} %{NOTSPACE:response_flags} %{NOTSPACE:response_code_details} %{NOTSPACE:connection_termination_details} \"%{DATA:upstream_transport_failure_reason}\" %{INT:bytes_received:int} %{INT:bytes_sent:int} %{INT:duration:int} %{INT:resp_upstream_service_time:int} \"%{DATA:req_x_forwarded_for}\" \"%{DATA:req_user_agent}\" \"%{DATA:req_x_request_id}\" \"%{DATA:req_authority}\" \"%{DATA:upstream_host}\" %{NOTSPACE:upstream_cluster} %{NOTSPACE:upstream_local_address} %{NOTSPACE:downstream_local_address} %{NOTSPACE:downstream_remote_address} %{NOTSPACE:requested_server_name} %{DATA:route_name}$")
+`
+	runner, err := NewTestingRunner(script)
+	if err != nil {
+		b.Fatal(err)
+	}
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": istioAccessLog}, time.Now())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if errR := runScript(runner, pt); errR != nil {
+			b.Fatal(errR)
+		}
+	}
+}
+
+func BenchmarkGrokIstioAccessTightPatternObserver(b *testing.B) {
+	SetGrokRunObserver(func(info GrokRunInfo) {})
+	b.Cleanup(func() { SetGrokRunObserver(nil) })
+
+	script := `
+grok(_, "^\\[%{TIMESTAMP_ISO8601:start_time}\\] \"%{WORD:http_method} %{DATA:http_path} %{NOTSPACE:protocol}\" %{INT:response_code:int} %{NOTSPACE:response_flags} %{NOTSPACE:response_code_details} %{NOTSPACE:connection_termination_details} \"%{DATA:upstream_transport_failure_reason}\" %{INT:bytes_received:int} %{INT:bytes_sent:int} %{INT:duration:int} %{INT:resp_upstream_service_time:int} \"%{DATA:req_x_forwarded_for}\" \"%{DATA:req_user_agent}\" \"%{DATA:req_x_request_id}\" \"%{DATA:req_authority}\" \"%{DATA:upstream_host}\" %{NOTSPACE:upstream_cluster} %{NOTSPACE:upstream_local_address} %{NOTSPACE:downstream_local_address} %{NOTSPACE:downstream_remote_address} %{NOTSPACE:requested_server_name} %{DATA:route_name}$")
+`
+	runner, err := NewTestingRunner(script)
+	if err != nil {
+		b.Fatal(err)
+	}
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": istioAccessLog}, time.Now())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if errR := runScript(runner, pt); errR != nil {
+			b.Fatal(errR)
+		}
+	}
+}
+
 const lp = `gin app="deployment-forethought-kodo-kodo",client_ip="172.1***03",cluster_name_k8s="k8s-daily",container_id="dcbacc667c1534127d4f4c531fc26f613f4e6f822e646dee4e4bdbc5e87920c4",container_name="kodo",deployment="kodo",filepath="/rootfs/var/log/pods/forethought-kodo_kodo-7dc8b5c448-rmcpb_bd5159c7-df57-4346-987d-fc6883aeabea/kodo/0.log",test_site="daily",host="cluster_a_cn-hangzhou.172.1***.102",host_ip="172.1***.102",image="registry.****.com/ko**:testing-202*****",log_read_lines=289892,message="[GIN] 2024/11/15 - 10:56:07 | 403 | 759.859µs |  172.16.200.203 | POST    \"/v1/write/metric?token=****************842cda605c6cb87e3a7b8\"",message_length=137,namespace="forethought-kodo",pod-template-hash="7dc8b5c448",pod_ip="10.113.0.204",pod_name="kodo-7dc8b5c448-rmcpb",real_host="hz--daily-002",region="cn-hangzhou",service="kodo",status="warning",time_ns=1731639367526632400,time_us=1731639367526632,timestamp="2024/11/15 - 10:56:07",zone_id="cn-hangzhou-j" 1731639367526000000`
 
 func BenchmarkParseLogNginx(b *testing.B) {

--- a/ptinput/funcs/grok_observer.go
+++ b/ptinput/funcs/grok_observer.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the MIT License.
+// This product includes software developed at Guance Cloud (https://www.guance.com/).
+// Copyright 2021-present Guance, Inc.
+
+package funcs
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/GuanceCloud/grok"
+)
+
+type GrokRunInfo struct {
+	ScriptName     string
+	Line           int
+	Column         int
+	PatternHash    uint64
+	Path           string
+	FallbackReason string
+	WorkUnits      int
+	Cost           time.Duration
+}
+
+type GrokRunObserver func(info GrokRunInfo)
+
+var grokRunObserver atomic.Value
+
+type grokRunObserverHolder struct {
+	observer GrokRunObserver
+}
+
+func SetGrokRunObserver(observer GrokRunObserver) {
+	grokRunObserver.Store(grokRunObserverHolder{observer: observer})
+}
+
+func currentGrokRunObserver() GrokRunObserver {
+	v := grokRunObserver.Load()
+	if v == nil {
+		return nil
+	}
+	return v.(grokRunObserverHolder).observer
+}
+
+func observeGrokRun(observer GrokRunObserver, scriptName string, line, column int, meta grok.RunMeta, start time.Time) {
+	if observer == nil {
+		return
+	}
+	observer(GrokRunInfo{
+		ScriptName:     scriptName,
+		Line:           line,
+		Column:         column,
+		PatternHash:    meta.PatternHash,
+		Path:           meta.Path.String(),
+		FallbackReason: meta.FallbackReason.String(),
+		WorkUnits:      meta.WorkUnits,
+		Cost:           time.Since(start),
+	})
+}


### PR DESCRIPTION
## Summary

- Add a process-wide grok run observer API for pipeline callers.
- Record script name, source position, grok pattern hash, execution path, fallback reason, work units, and cost.
- Route pipeline `grok()` through metadata-aware grok calls only when an observer is registered; the default path keeps using the original `Run`/`RunWithTypeInfo` calls.
- Add observer coverage and benchmarks for the Istio access-log patterns involved in the performance regression investigation.

## Validation

- `go test ./ptinput/funcs`
- `go test -run '^$' -bench 'BenchmarkGrokIstioAccess' ./ptinput/funcs`
- `go test ./...` still has existing failures in `pkg/arbiter/request/TestHostFilte` test4/test5, unrelated to this change.