### PR TITLE
[codex] Restore time_now current timestamp

### DIFF
--- a/pkg/arbiter/builtin-funcs/cases.go
+++ b/pkg/arbiter/builtin-funcs/cases.go
@@ -933,12 +933,6 @@ var cTimeNow = &FuncExample{
 			Script: `printf("%v", time_now("s"))
 `,
 			Stdout: "1672531500",
-			privateData: map[string]any{
-				"time_range": []int64{
-					1672531500000,
-					1672532100000,
-				},
-			},
 		},
 	},
 }

--- a/pkg/arbiter/builtin-funcs/docs/function_doc.md
+++ b/pkg/arbiter/builtin-funcs/docs/function_doc.md
@@ -1788,7 +1788,7 @@ Function examples:
 
 Function prototype: `fn time_now(precision: str = "ns") -> int`
 
-Function description: Get the DQL query start timestamp with the specified precision.
+Function description: Get the current timestamp with the specified precision.
 
 Function parameters:
 
@@ -1797,7 +1797,7 @@ Function parameters:
 
 Function returns:
 
-- `int`: Returns the DQL query start timestamp.
+- `int`: Returns the current timestamp.
 
 
 Function examples:

--- a/pkg/arbiter/builtin-funcs/docs/function_doc.zh.md
+++ b/pkg/arbiter/builtin-funcs/docs/function_doc.zh.md
@@ -1788,7 +1788,7 @@
 
 函数原型： `fn time_now(precision: str = "ns") -> int`
 
-函数描述： Get the DQL query start timestamp with the specified precision.
+函数描述： Get the current timestamp with the specified precision.
 
 函数参数：
 
@@ -1797,7 +1797,7 @@
 
 函数返回值：
 
-- `int`: Returns the DQL query start timestamp.
+- `int`: Returns the current timestamp.
 
 
 函数示例：

--- a/pkg/arbiter/builtin-funcs/fn_timenow.go
+++ b/pkg/arbiter/builtin-funcs/fn_timenow.go
@@ -6,18 +6,18 @@
 package funcs
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/GuanceCloud/pipeline-go/pkg/arbiter/dql"
 	"github.com/GuanceCloud/platypus/pkg/ast"
 	"github.com/GuanceCloud/platypus/pkg/engine/runtimev2"
 	"github.com/GuanceCloud/platypus/pkg/errchain"
 )
 
+var timeNow = time.Now
+
 var FnTimeNowDesc = runtimev2.FnDesc{
 	Name: "time_now",
-	Desc: "Get the DQL query start timestamp with the specified precision.",
+	Desc: "Get the current timestamp with the specified precision.",
 	Params: []*runtimev2.Param{
 		{
 			Name: "precision",
@@ -28,7 +28,7 @@ var FnTimeNowDesc = runtimev2.FnDesc{
 	},
 	Returns: []*runtimev2.Param{
 		{
-			Desc: "Returns the DQL query start timestamp.",
+			Desc: "Returns the current timestamp.",
 			Typs: []ast.DType{ast.Int},
 		},
 	},
@@ -44,41 +44,22 @@ func FnTimenow(ctx *runtimev2.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 		return err
 	}
 
-	start, err := dqlQueryStartTime(ctx, funcExpr)
-	if err != nil {
-		return err
-	}
-
-	switch precision {
-	case "us":
-		start *= int64(time.Millisecond / time.Microsecond)
-	case "ms":
-	case "s":
-		start /= int64(time.Second / time.Millisecond)
-	default:
-		start *= int64(time.Millisecond / time.Nanosecond)
-	}
 	ctx.Regs.ReturnAppend(
-		runtimev2.V{V: start, T: ast.Int},
+		runtimev2.V{V: currentTimestamp(precision), T: ast.Int},
 	)
 	return nil
 }
 
-func dqlQueryStartTime(ctx *runtimev2.Task, expr *ast.CallExpr) (int64, *errchain.PlError) {
-	v, ok := ctx.PValue(PDQLCli)
-	if !ok {
-		return 0, runtimev2.NewRunError(ctx, fmt.Sprintf(
-			"missing context data named %s", PDQLCli), expr.NamePos)
+func currentTimestamp(precision string) int64 {
+	now := timeNow()
+	switch precision {
+	case "s":
+		return now.Unix()
+	case "ms":
+		return now.UnixMilli()
+	case "us":
+		return now.UnixMicro()
+	default:
+		return now.UnixNano()
 	}
-	dqlCli, ok := v.(dql.DQL)
-	if !ok {
-		return 0, runtimev2.NewRunError(ctx, fmt.Sprintf(
-			"context data %s type is expected", PDQLCli), expr.NamePos)
-	}
-
-	r := dqlCli.TimeRange()
-	if len(r) == 2 {
-		return r[0], nil
-	}
-	return genTimeRange15min(time.Now().UnixMilli()), nil
 }

--- a/pkg/arbiter/builtin-funcs/fn_timnow_test.go
+++ b/pkg/arbiter/builtin-funcs/fn_timnow_test.go
@@ -7,29 +7,29 @@ package funcs
 
 import (
 	"testing"
-
-	"github.com/GuanceCloud/pipeline-go/pkg/arbiter/dql"
-	"github.com/GuanceCloud/platypus/pkg/engine/runtimev2"
+	"time"
 )
 
 func TestTimestamp(t *testing.T) {
+	originTimeNow := timeNow
+	timeNow = func() time.Time {
+		return time.Unix(1672531500, 123456789)
+	}
+	defer func() {
+		timeNow = originTimeNow
+	}()
+
 	cases := []ProgCase{
 		{
-			Name: "time_now_returns_query_start",
+			Name: "time_now_returns_current_time",
 			Script: `printf("%v,%v,%v,%v", time_now("s"), time_now("ms"), time_now("us"), time_now("ns"))
 `,
-			Stdout: "1672531500,1672531500123,1672531500123000,1672531500123000000",
+			Stdout: "1672531500,1672531500123,1672531500123456,1672531500123456789",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			runCase(t, c, map[runtimev2.TaskP]any{
-				PDQLCli: dql.NewDQLKodo(
-					"",
-					"abc",
-					[]int64{1672531500123, 1672532100123},
-				),
-			})
+			runCase(t, c)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Restore arbiter `time_now` to return the wall-clock current timestamp for the requested precision instead of the DQL query start time.

## Why

Commit `e83f4dda4efadd75f024e5e71fbb803dfc89fbc6` changed `time_now` to depend on the DQL query time range. This PR restores the earlier behavior where `time_now("s"|"ms"|"us"|"ns")` reads the current time directly.

## Changes

- Remove the `PDQLCli` / DQL `TimeRange()` dependency from `time_now`.
- Return `Unix`, `UnixMilli`, `UnixMicro`, or `UnixNano` based on the requested precision.
- Update tests to use a fixed nanosecond timestamp so precision truncation is caught.
- Regenerate the English and Chinese function docs.

## Validation

- `go test ./pkg/arbiter/builtin-funcs`