### PR TITLE
[codex] Add dql_series_first helper

### DIFF
--- a/pkg/arbiter/builtin-funcs/all_funcs.go
+++ b/pkg/arbiter/builtin-funcs/all_funcs.go
@@ -48,6 +48,11 @@ var Funcs = map[string]*runtimev2.Fn{
 		Call:      FnDQLSeriesGet,
 		Desc:      FnDQLSeriesGetDesc,
 	},
+	FnDQLSeriesFirstDesc.Name: {
+		CallCheck: FnDQLSeriesFirstCheck,
+		Call:      FnDQLSeriesFirst,
+		Desc:      FnDQLSeriesFirstDesc,
+	},
 	FnDQLTimerangeGetDesc.Name: {
 		CallCheck: FnDQLTimerangeGetCheck,
 		Call:      FnDQLTimerangeGet,

--- a/pkg/arbiter/builtin-funcs/cases.go
+++ b/pkg/arbiter/builtin-funcs/cases.go
@@ -333,6 +333,42 @@ printf("%v", {"host": hostLi, "time": time_li})
 		},
 	},
 }
+
+var _ = AddExps(cDQLSeriesFirst)
+var cDQLSeriesFirst = &FuncExample{
+	FnName: FnDQLSeriesFirstDesc.Name,
+	Progs: []ProgCase{
+		{
+			Name: "dql_series_first",
+			Script: `v = dql("M::cpu limit 2 slimit 2")
+
+host = dql_series_first(v, "host")
+time = dql_series_first(v, "time")
+
+printf("%v", {"host": host, "time": time})
+`,
+			jsonout: true,
+			Stdout:  `{"host":"172.16.241.111","time":1744866108991}`,
+		},
+		{
+			Name: "dql_series_first_trigger_dimension_tags",
+			Script: `v = dql("M::cpu limit 1 slimit 1")
+
+host = dql_series_first(v, "host")
+trigger(host, "high", dimension_tags={"host": host}, related_data={})
+`,
+			TriggerResult: []trigger.Data{
+				{
+					Result:        "172.16.241.111",
+					Status:        "high",
+					DimensionTags: map[string]string{"host": "172.16.241.111"},
+					RelatedData:   map[string]any{},
+				},
+			},
+		},
+	},
+}
+
 var _ = AddExps(cDumpJSON)
 var cDumpJSON = &FuncExample{
 	FnName: FnDumpJSONDesc.Name,

--- a/pkg/arbiter/builtin-funcs/docs/function_doc.md
+++ b/pkg/arbiter/builtin-funcs/docs/function_doc.md
@@ -465,6 +465,81 @@ Function examples:
 
     
 
+## `dql_series_first` {#fn-dql_series_first}
+
+Function prototype: `fn dql_series_first(series: map, name: str) -> bool|int|float|str|list|map|nil`
+
+Function description: get the first column or tag value from series data
+
+Function parameters:
+
+- `series`: dql query result
+- `name`: column or tag name
+
+
+Function returns:
+
+- `bool|int|float|str|list|map|nil`: first specified column or tag value for the series
+
+
+Function examples:
+
+* Case 0:
+
+    Script content:
+
+    ```txt
+    v = dql("M::cpu limit 2 slimit 2")
+    
+    host = dql_series_first(v, "host")
+    time = dql_series_first(v, "time")
+    
+    printf("%v", {"host": host, "time": time})
+    
+    ```
+
+    Standard output:
+
+    ```txt
+    {"host":"172.16.241.111","time":1744866108991}
+    ```
+
+    
+* Case 1:
+
+    Script content:
+
+    ```txt
+    v = dql("M::cpu limit 1 slimit 1")
+    
+    host = dql_series_first(v, "host")
+    trigger(host, "high", dimension_tags={"host": host}, related_data={})
+    
+    ```
+
+    Standard output:
+
+    ```txt
+    
+    ```
+
+    
+    Trigger output:
+    ```json
+    [
+        {
+            "result": "172.16.241.111",
+            "status": "high",
+            "dimension_tags": {
+                "host": "172.16.241.111"
+            },
+            "related_data": {},
+            "check_workspace_uuid": ""
+        }
+    ]
+    
+    ```
+
 ## `dql_series_get` {#fn-dql_series_get}
 
 Function prototype: `fn dql_series_get(series: map, name: str) -> list`

--- a/pkg/arbiter/builtin-funcs/docs/function_doc.zh.md
+++ b/pkg/arbiter/builtin-funcs/docs/function_doc.zh.md
@@ -465,6 +465,81 @@
 
     
 
+## `dql_series_first` {#fn-dql_series_first}
+
+函数原型： `fn dql_series_first(series: map, name: str) -> bool|int|float|str|list|map|nil`
+
+函数描述： get the first column or tag value from series data
+
+函数参数：
+
+- `series`: dql query result
+- `name`: column or tag name
+
+
+函数返回值：
+
+- `bool|int|float|str|list|map|nil`: first specified column or tag value for the series
+
+
+函数示例：
+
+* 示例 0:
+
+    脚本内容：
+
+    ```txt
+    v = dql("M::cpu limit 2 slimit 2")
+    
+    host = dql_series_first(v, "host")
+    time = dql_series_first(v, "time")
+    
+    printf("%v", {"host": host, "time": time})
+    
+    ```
+
+    标准输出：
+
+    ```txt
+    {"host":"172.16.241.111","time":1744866108991}
+    ```
+
+    
+* 示例 1:
+
+    脚本内容：
+
+    ```txt
+    v = dql("M::cpu limit 1 slimit 1")
+    
+    host = dql_series_first(v, "host")
+    trigger(host, "high", dimension_tags={"host": host}, related_data={})
+    
+    ```
+
+    标准输出：
+
+    ```txt
+    
+    ```
+
+    
+    触发器输出：
+    ```json
+    [
+        {
+            "result": "172.16.241.111",
+            "status": "high",
+            "dimension_tags": {
+                "host": "172.16.241.111"
+            },
+            "related_data": {},
+            "check_workspace_uuid": ""
+        }
+    ]
+    
+    ```
+
 ## `dql_series_get` {#fn-dql_series_get}
 
 函数原型： `fn dql_series_get(series: map, name: str) -> list`

--- a/pkg/arbiter/builtin-funcs/fn_dql_series_get.go
+++ b/pkg/arbiter/builtin-funcs/fn_dql_series_get.go
@@ -29,8 +29,35 @@ var FnDQLSeriesGetDesc = runtimev2.FnDesc{
 	},
 }
 
+var FnDQLSeriesFirstDesc = runtimev2.FnDesc{
+	Name: "dql_series_first",
+	Desc: "get the first column or tag value from series data",
+	Params: []*runtimev2.Param{
+		{
+			Name: "series",
+			Desc: "dql query result",
+			Typs: []ast.DType{ast.Map},
+		},
+		{
+			Name: "name",
+			Desc: "column or tag name",
+			Typs: []ast.DType{ast.String},
+		},
+	},
+	Returns: []*runtimev2.Param{
+		{
+			Desc: "first specified column or tag value for the series",
+			Typs: []ast.DType{ast.Bool, ast.Int, ast.Float, ast.String, ast.List, ast.Map, ast.Nil},
+		},
+	},
+}
+
 func FnDQLSeriesGetCheck(ctx *runtimev2.Task, expr *ast.CallExpr) *errchain.PlError {
 	return runtimev2.CheckPassParam(ctx, expr, FnDQLSeriesGetDesc.Params)
+}
+
+func FnDQLSeriesFirstCheck(ctx *runtimev2.Task, expr *ast.CallExpr) *errchain.PlError {
+	return runtimev2.CheckPassParam(ctx, expr, FnDQLSeriesFirstDesc.Params)
 }
 
 func FnDQLSeriesGet(ctx *runtimev2.Task, expr *ast.CallExpr) *errchain.PlError {
@@ -43,6 +70,32 @@ func FnDQLSeriesGet(ctx *runtimev2.Task, expr *ast.CallExpr) *errchain.PlError {
 		return err
 	}
 
+	ctx.Regs.ReturnAppend(runtimev2.V{T: ast.List, V: dqlSeriesValues(dqlResult, name)})
+
+	return nil
+}
+
+func FnDQLSeriesFirst(ctx *runtimev2.Task, expr *ast.CallExpr) *errchain.PlError {
+	dqlResult, err := runtimev2.GetParamMap(ctx, expr, FnDQLSeriesFirstDesc.Params, 0)
+	if err != nil {
+		return err
+	}
+	name, err := runtimev2.GetParamString(ctx, expr, FnDQLSeriesFirstDesc.Params, 1)
+	if err != nil {
+		return err
+	}
+
+	v := dqlSeriesFirstValue(dqlResult, name)
+	v, typ := ast.DectDataType(v)
+	if typ == ast.Invalid {
+		v, typ = nil, ast.Nil
+	}
+	ctx.Regs.ReturnAppend(runtimev2.V{T: typ, V: v})
+
+	return nil
+}
+
+func dqlSeriesValues(dqlResult map[string]any, name string) []any {
 	vecVec := []any{}
 
 	tagOrCol := -1
@@ -97,8 +150,16 @@ func FnDQLSeriesGet(ctx *runtimev2.Task, expr *ast.CallExpr) *errchain.PlError {
 		vecVec = append(vecVec, vec)
 	}
 
-	ctx.Regs.ReturnAppend(runtimev2.V{T: ast.List, V: vecVec})
+	return vecVec
+}
 
+func dqlSeriesFirstValue(dqlResult map[string]any, name string) any {
+	for _, vec := range dqlSeriesValues(dqlResult, name) {
+		values := getList(vec)
+		if len(values) > 0 {
+			return values[0]
+		}
+	}
 	return nil
 }
 

--- a/pkg/arbiter/builtin-funcs/fn_dql_series_get_test.go
+++ b/pkg/arbiter/builtin-funcs/fn_dql_series_get_test.go
@@ -14,6 +14,7 @@ func TestFuncDQLSeries(t *testing.T) {
 	defer server.Close()
 	cases := []ProgCase{}
 	cases = append(cases, cDQLSeriesGet.Progs...)
+	cases = append(cases, cDQLSeriesFirst.Progs...)
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			runCase(t, tc, map[runtimev2.TaskP]any{


### PR DESCRIPTION
## Summary

Add `dql_series_first(series, name)` for scripts that need the first DQL column or tag value directly.

## Why

`dql_series_get` returns a two-dimensional list that preserves the DQL series structure. That is useful for bulk access, but awkward for fields such as `trigger(..., dimension_tags={"host": ...})`, where the tag value needs to be a plain string. This helper keeps the same column/tag lookup behavior and returns the first value directly.

## Changes

- Add and register `dql_series_first`.
- Reuse the existing `dql_series_get` column/tag extraction logic.
- Return the detected scalar/list/map/nil type for the first value.
- Add examples and tests, including a `trigger` dimension tag use case.
- Regenerate English and Chinese function docs.

## Validation

- `go test ./pkg/arbiter/builtin-funcs ./internal/command/arbitercheck`