### PR TITLE
[codex] enable scoped JSON extraction helpers

### DIFF
--- a/ptinput/funcs/all.go
+++ b/ptinput/funcs/all.go
@@ -52,6 +52,7 @@ var FuncsMap = map[string]runtime.FuncCall{
 	"delete":                 DeleteMapItem,
 	"adjust_timezone":        AdjustTimezone,
 	"json":                   JSON,
+	"json_all":               JSONAll,
 	"add_pattern":            AddPattern,
 	"b64dec":                 B64dec,
 	"b64enc":                 B64enc,
@@ -110,6 +111,7 @@ var FuncsMap = map[string]runtime.FuncCall{
 	"point_window":           PtWindow,
 	"window_hit":             PtWindowHit,
 	"pt_kvs_set":             FnPtKvsSet.Call,
+	"pt_kvs_set_map":         FnPtKvsSetMap.Call,
 	"pt_kvs_get":             FnPtKvsGet.Call,
 	"pt_kvs_del":             FnPtKvsDel.Call,
 	"pt_kvs_keys":            FnPtKvsKeys.Call,
@@ -119,9 +121,6 @@ var FuncsMap = map[string]runtime.FuncCall{
 	"strlen": StrLen,
 
 	"setopt": Setopt,
-
-	// disable
-	"json_all": JSONAll,
 }
 
 var FuncsCheckMap = map[string]runtime.FuncCheck{
@@ -134,6 +133,7 @@ var FuncsCheckMap = map[string]runtime.FuncCheck{
 	"delete":                 DeleteMapItemChecking,
 	"adjust_timezone":        AdjustTimezoneChecking,
 	"json":                   JSONChecking,
+	"json_all":               JSONAllChecking,
 	"add_pattern":            AddPatternChecking,
 	"b64dec":                 B64decChecking,
 	"b64enc":                 B64encChecking,
@@ -192,15 +192,13 @@ var FuncsCheckMap = map[string]runtime.FuncCheck{
 	"point_window":           PtWindowChecking,
 	"window_hit":             PtWindowHitChecking,
 
-	"pt_kvs_set":   FnPtKvsSet.Check,
-	"pt_kvs_get":   FnPtKvsGet.Check,
-	"pt_kvs_del":   FnPtKvsDel.Check,
-	"pt_kvs_keys":  FnPtKvsKeys.Check,
-	"hash":         FnHash.Check,
-	"slice_string": FnSliceString.Check,
-
-	// disable
-	"json_all": JSONAllChecking,
+	"pt_kvs_set":     FnPtKvsSet.Check,
+	"pt_kvs_set_map": FnPtKvsSetMap.Check,
+	"pt_kvs_get":     FnPtKvsGet.Check,
+	"pt_kvs_del":     FnPtKvsDel.Check,
+	"pt_kvs_keys":    FnPtKvsKeys.Check,
+	"hash":           FnHash.Check,
+	"slice_string":   FnSliceString.Check,
 
 	"strlen": StrLenChecking,
 	"setopt": SetoptChecking,

--- a/ptinput/funcs/all_doc.go
+++ b/ptinput/funcs/all_doc.go
@@ -47,6 +47,7 @@ var PipelineFunctionDocs = map[string]*PLDoc{
 	"group_in()":               &groupInMarkdown,
 	"kv_split()":               &kvSplitMarkdown,
 	"json()":                   &jsonMarkdown,
+	"json_all()":               &jsonAllMarkdown,
 	"len()":                    &lenMarkdown,
 	"load_json()":              &loadJSONMarkdown,
 	"lowercase()":              &lowercaseMarkdown,
@@ -85,6 +86,7 @@ var PipelineFunctionDocs = map[string]*PLDoc{
 	"point_window()":           &pointWinodoeMarkdown,
 	"window_hit()":             &winHitMarkdown,
 	"pt_kvs_set()":             FnPtKvsSet.Doc[0],
+	"pt_kvs_set_map()":         FnPtKvsSetMap.Doc[0],
 	"pt_kvs_get()":             FnPtKvsGet.Doc[0],
 	"pt_kvs_del()":             FnPtKvsDel.Doc[0],
 	"pt_kvs_keys()":            FnPtKvsKeys.Doc[0],
@@ -122,6 +124,7 @@ var PipelineFunctionDocsEN = map[string]*PLDoc{
 	"group_in()":               &groupInMarkdownEN,
 	"kv_split()":               &kvSplitMarkdownEN,
 	"json()":                   &jsonMarkdownEN,
+	"json_all()":               &jsonAllMarkdownEN,
 	"len()":                    &lenMarkdownEN,
 	"load_json()":              &loadJSONMarkdownEN,
 	"lowercase()":              &lowercaseMarkdownEN,
@@ -160,6 +163,7 @@ var PipelineFunctionDocsEN = map[string]*PLDoc{
 	"point_window()":           &pointWinodoeMarkdownEN,
 	"window_hit()":             &winHitMarkdownEN,
 	"pt_kvs_set()":             FnPtKvsSet.Doc[1],
+	"pt_kvs_set_map()":         FnPtKvsSetMap.Doc[1],
 	"pt_kvs_get()":             FnPtKvsGet.Doc[1],
 	"pt_kvs_del()":             FnPtKvsDel.Doc[1],
 	"pt_kvs_keys()":            FnPtKvsKeys.Doc[1],
@@ -198,6 +202,9 @@ var (
 
 	//go:embed md/json.md
 	docJSON string
+
+	//go:embed md/json_all.md
+	docJSONAll string
 
 	//go:embed md/query_refer_table.md
 	docQueryReferTable string
@@ -553,6 +560,12 @@ var (
 	}
 	jsonMarkdown = PLDoc{
 		Doc: docJSON, Deprecated: false,
+		FnCategory: map[string][]string{
+			langTagZhCN: {cJSON},
+		},
+	}
+	jsonAllMarkdown = PLDoc{
+		Doc: docJSONAll, Deprecated: false,
 		FnCategory: map[string][]string{
 			langTagZhCN: {cJSON},
 		},

--- a/ptinput/funcs/all_doc_en.go
+++ b/ptinput/funcs/all_doc_en.go
@@ -39,6 +39,9 @@ var (
 	//go:embed md/json.en.md
 	docJSONEN string
 
+	//go:embed md/json_all.en.md
+	docJSONAllEN string
+
 	//go:embed md/query_refer_table.en.md
 	docQueryReferTableEN string
 
@@ -390,6 +393,12 @@ var (
 	}
 	jsonMarkdownEN = PLDoc{
 		Doc: docJSONEN, Deprecated: false,
+		FnCategory: map[string][]string{
+			langTagEnUS: {eJSON},
+		},
+	}
+	jsonAllMarkdownEN = PLDoc{
+		Doc: docJSONAllEN, Deprecated: false,
 		FnCategory: map[string][]string{
 			langTagEnUS: {eJSON},
 		},

--- a/ptinput/funcs/all_doc_en_test.go
+++ b/ptinput/funcs/all_doc_en_test.go
@@ -20,8 +20,7 @@ func TestAllDocEn(t *testing.T) {
 		funcNameMap[strings.TrimSuffix(name, "()")] = true
 	}
 	for fn := range FuncsMap {
-		if fn == "json_all" ||
-			fn == "default_time_with_fmt" ||
+		if fn == "default_time_with_fmt" ||
 			fn == "expr" ||
 			fn == "vaild_json" {
 			continue

--- a/ptinput/funcs/all_doc_test.go
+++ b/ptinput/funcs/all_doc_test.go
@@ -17,8 +17,7 @@ func TestAllDoc(t *testing.T) {
 		funcNameMap[strings.TrimSuffix(name, "()")] = true
 	}
 	for fn := range FuncsMap {
-		if fn == "json_all" ||
-			fn == "default_time_with_fmt" ||
+		if fn == "default_time_with_fmt" ||
 			fn == "expr" ||
 			fn == "vaild_json" {
 			continue

--- a/ptinput/funcs/fn_jsonall.go
+++ b/ptinput/funcs/fn_jsonall.go
@@ -6,17 +6,363 @@
 package funcs
 
 import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+
+	"github.com/goccy/go-json"
+
+	"github.com/GuanceCloud/pipeline-go/ptinput"
 	"github.com/GuanceCloud/platypus/pkg/ast"
 	"github.com/GuanceCloud/platypus/pkg/engine/runtime"
 	"github.com/GuanceCloud/platypus/pkg/errchain"
 )
 
+type compiledJSONAllCall struct {
+	srcKey           string
+	includeKeys      map[string]struct{}
+	includeStatic    bool
+	includeProvided  bool
+	keyPatterns      []*regexp.Regexp
+	patternsStatic   bool
+	patternsProvided bool
+}
+
 func JSONAllChecking(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	l.Debugf("warning: json_all() is disabled")
+	if err := normalizeFuncArgsDeprecated(funcExpr, []string{
+		"input", "include_keys", "key_patterns",
+	}, 1); err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.NamePos)
+	}
+
+	srcKey, err := getKeyName(funcExpr.Param[0])
+	if err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
+	}
+
+	includeKeys, includeStatic, includeProvided, err := staticJSONAllIncludeKeys(funcExpr.Param[1])
+	if err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[1].StartPos())
+	}
+
+	keyPatterns, patternsStatic, patternsProvided, err := staticJSONAllKeyPatterns(funcExpr.Param[2])
+	if err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[2].StartPos())
+	}
+
+	funcExpr.PrivateData = &compiledJSONAllCall{
+		srcKey:           srcKey,
+		includeKeys:      includeKeys,
+		includeStatic:    includeStatic,
+		includeProvided:  includeProvided,
+		keyPatterns:      keyPatterns,
+		patternsStatic:   patternsStatic,
+		patternsProvided: patternsProvided,
+	}
+
 	return nil
 }
 
 func JSONAll(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	l.Debugf("warning: json_all() is disabled")
+	opts := getCompiledJSONAllCall(funcExpr)
+	if opts == nil {
+		if len(funcExpr.Param) == 0 || funcExpr.Param[0] == nil {
+			return runtime.NewRunError(ctx, "parameter input is required", funcExpr.NamePos)
+		}
+		srcKey, err := getKeyName(funcExpr.Param[0])
+		if err != nil {
+			return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
+		}
+		opts = &compiledJSONAllCall{srcKey: srcKey}
+		if len(funcExpr.Param) > 1 && funcExpr.Param[1] != nil {
+			includeKeys, includeStatic, includeProvided, err := staticJSONAllIncludeKeys(funcExpr.Param[1])
+			if err != nil {
+				return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[1].StartPos())
+			}
+			opts.includeKeys = includeKeys
+			opts.includeStatic = includeStatic
+			opts.includeProvided = includeProvided
+		}
+		if len(funcExpr.Param) > 2 && funcExpr.Param[2] != nil {
+			keyPatterns, patternsStatic, patternsProvided, err := staticJSONAllKeyPatterns(funcExpr.Param[2])
+			if err != nil {
+				return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[2].StartPos())
+			}
+			opts.keyPatterns = keyPatterns
+			opts.patternsStatic = patternsStatic
+			opts.patternsProvided = patternsProvided
+		}
+	}
+
+	includeKeys := opts.includeKeys
+	includeProvided := opts.includeProvided
+	if !opts.includeStatic && len(funcExpr.Param) > 1 && funcExpr.Param[1] != nil {
+		var err *errchain.PlError
+		includeKeys, includeProvided, err = runtimeJSONAllIncludeKeys(ctx, funcExpr.Param[1])
+		if err != nil {
+			return err
+		}
+	}
+
+	keyPatterns := opts.keyPatterns
+	patternsProvided := opts.patternsProvided
+	if !opts.patternsStatic && len(funcExpr.Param) > 2 && funcExpr.Param[2] != nil {
+		var err *errchain.PlError
+		keyPatterns, patternsProvided, err = runtimeJSONAllKeyPatterns(ctx, funcExpr.Param[2])
+		if err != nil {
+			return err
+		}
+	}
+
+	filterInclude := includeProvided || patternsProvided
+	if !filterInclude {
+		return nil
+	}
+
+	cont, err := ctx.GetKeyConv2Str(opts.srcKey)
+	if err != nil {
+		l.Debug(err)
+		return nil
+	}
+
+	var data any
+	if err := json.Unmarshal([]byte(cont), &data); err != nil {
+		l.Debug(err)
+		return nil
+	}
+
+	state := &jsonAllWalkState{
+		ctx:           ctx,
+		includeKeys:   includeKeys,
+		keyPatterns:   keyPatterns,
+		filterInclude: filterInclude,
+	}
+	state.walk(data, "")
+
 	return nil
+}
+
+func getCompiledJSONAllCall(funcExpr *ast.CallExpr) *compiledJSONAllCall {
+	if funcExpr == nil {
+		return nil
+	}
+	if compiled, ok := funcExpr.PrivateData.(*compiledJSONAllCall); ok {
+		return compiled
+	}
+	return nil
+}
+
+func staticJSONAllIncludeKeys(node *ast.Node) (map[string]struct{}, bool, bool, error) {
+	keys, static, provided, err := staticJSONAllStringList(node, "include_keys")
+	if err != nil {
+		return nil, static, provided, err
+	}
+	return jsonAllStringSet(keys), static, provided, nil
+}
+
+func staticJSONAllKeyPatterns(node *ast.Node) ([]*regexp.Regexp, bool, bool, error) {
+	patterns, static, provided, err := staticJSONAllStringList(node, "key_patterns")
+	if err != nil {
+		return nil, static, provided, err
+	}
+	if !static {
+		return nil, static, provided, nil
+	}
+	compiled, err := compileJSONAllKeyPatterns(patterns)
+	return compiled, static, provided, err
+}
+
+func staticJSONAllStringList(node *ast.Node, paramName string) ([]string, bool, bool, error) {
+	if node == nil {
+		return nil, true, false, nil
+	}
+	if node.NodeType == ast.TypeNilLiteral {
+		return nil, true, false, nil
+	}
+
+	if node.NodeType != ast.TypeListLiteral {
+		switch node.NodeType { //nolint:exhaustive
+		case ast.TypeIdentifier, ast.TypeAttrExpr, ast.TypeCallExpr:
+			return nil, false, true, nil
+		default:
+			return nil, false, true, fmt.Errorf("param %s expect ListLiteral, got %s", paramName, node.NodeType)
+		}
+	}
+
+	keys := make([]string, 0, len(node.ListLiteral().List))
+	for _, elem := range node.ListLiteral().List {
+		if elem.NodeType != ast.TypeStringLiteral {
+			return nil, true, true, fmt.Errorf("param %s element expect StringLiteral, got %s",
+				paramName, elem.NodeType)
+		}
+		keys = append(keys, elem.StringLiteral().Val)
+	}
+	return keys, true, true, nil
+}
+
+func runtimeJSONAllIncludeKeys(ctx *runtime.Task, node *ast.Node) (map[string]struct{}, bool, *errchain.PlError) {
+	keys, provided, err := runtimeJSONAllStringList(ctx, node, "include_keys")
+	if err != nil {
+		return nil, provided, err
+	}
+	return jsonAllStringSet(keys), provided, nil
+}
+
+func runtimeJSONAllKeyPatterns(ctx *runtime.Task, node *ast.Node) ([]*regexp.Regexp, bool, *errchain.PlError) {
+	patterns, provided, err := runtimeJSONAllStringList(ctx, node, "key_patterns")
+	if err != nil {
+		return nil, provided, err
+	}
+	if !provided {
+		return nil, false, nil
+	}
+
+	compiled, errCompile := compileJSONAllKeyPatterns(patterns)
+	if errCompile != nil {
+		return nil, provided, runtime.NewRunError(ctx, errCompile.Error(), node.StartPos())
+	}
+	return compiled, true, nil
+}
+
+func runtimeJSONAllStringList(ctx *runtime.Task, node *ast.Node, paramName string) ([]string, bool, *errchain.PlError) {
+	val, dtype, err := runtime.RunStmt(ctx, node)
+	if err != nil {
+		return nil, false, err
+	}
+	if dtype == ast.Nil {
+		return nil, false, nil
+	}
+	if dtype != ast.List {
+		return nil, false, runtime.NewRunError(ctx, fmt.Sprintf("param %s expect list", paramName), node.StartPos())
+	}
+
+	keys, ok := val.([]any)
+	if !ok {
+		return nil, false, runtime.NewRunError(ctx, fmt.Sprintf("param %s expect list", paramName), node.StartPos())
+	}
+
+	strKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		keyStr, ok := key.(string)
+		if !ok {
+			return nil, true, runtime.NewRunError(ctx, fmt.Sprintf("param %s element expect string", paramName),
+				node.StartPos())
+		}
+		strKeys = append(strKeys, keyStr)
+	}
+	return strKeys, true, nil
+}
+
+func jsonAllStringSet(keys []string) map[string]struct{} {
+	if keys == nil {
+		return nil
+	}
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		set[key] = struct{}{}
+	}
+	return set
+}
+
+func compileJSONAllKeyPatterns(patterns []string) ([]*regexp.Regexp, error) {
+	if patterns == nil {
+		return nil, nil
+	}
+
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		re, err := regexp.Compile("^" + ptKvsWildcardToRegexp(pattern) + "$")
+		if err != nil {
+			return nil, err
+		}
+		compiled = append(compiled, re)
+	}
+	return compiled, nil
+}
+
+type jsonAllWalkState struct {
+	ctx           *runtime.Task
+	includeKeys   map[string]struct{}
+	keyPatterns   []*regexp.Regexp
+	filterInclude bool
+}
+
+func (s *jsonAllWalkState) walk(v any, path string) bool {
+	if path != "" {
+		return s.add(path, v)
+	}
+
+	switch v := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			if !s.add(key, v[key]) {
+				return false
+			}
+		}
+	case []any:
+		for i, elem := range v {
+			if !s.add(jsonAllArrayIndex(i), elem) {
+				return false
+			}
+		}
+	default:
+		return s.add(path, v)
+	}
+	return true
+}
+
+func (s *jsonAllWalkState) add(path string, v any) bool {
+	if path == "" {
+		return true
+	}
+
+	if s.filterInclude {
+		if !s.match(path) {
+			return true
+		}
+	}
+
+	dtype, ok := jsonAllDType(v)
+	if !ok {
+		return true
+	}
+
+	addKey2PtWithVal(s.ctx.InData(), path, v, dtype, ptinput.KindPtDefault)
+	return true
+}
+
+func (s *jsonAllWalkState) match(path string) bool {
+	if _, ok := s.includeKeys[path]; ok {
+		return true
+	}
+	for _, pattern := range s.keyPatterns {
+		if pattern.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonAllDType(v any) (ast.DType, bool) {
+	switch v.(type) {
+	case bool:
+		return ast.Bool, true
+	case float64:
+		return ast.Float, true
+	case string:
+		return ast.String, true
+	default:
+		return ast.Invalid, false
+	}
+}
+
+func jsonAllArrayIndex(idx int) string {
+	return "[" + strconv.Itoa(idx) + "]"
 }

--- a/ptinput/funcs/fn_jsonall_test.go
+++ b/ptinput/funcs/fn_jsonall_test.go
@@ -1,0 +1,237 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the MIT License.
+// This product includes software developed at Guance Cloud (https://www.guance.com/).
+// Copyright 2021-present Guance, Inc.
+
+package funcs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GuanceCloud/cliutils/point"
+	"github.com/GuanceCloud/pipeline-go/ptinput"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONAllIncludeKeys(t *testing.T) {
+	runner, err := NewTestingRunner(`json_all(_, include_keys=[
+		"age",
+		"active",
+		"service",
+		"name.first",
+	])`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `{
+			"service": "api",
+			"name": {"first": "Tom", "last": "Anderson"},
+			"age": 37,
+			"active": true,
+			"children": ["Sara", "Alex", "Jack"],
+			"friends": [
+				{"first": "Dale", "age": 44},
+				{"first": "Roger", "age": 68}
+			]
+		}`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	cases := map[string]any{
+		"service": "api",
+		"age":     float64(37),
+		"active":  true,
+	}
+	for key, want := range cases {
+		got, _, err := pt.Get(key)
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+
+	_, _, err = pt.Get("name")
+	assert.Error(t, err)
+	_, _, err = pt.Get("name.first")
+	assert.Error(t, err)
+	_, _, err = pt.Get("children")
+	assert.Error(t, err)
+	_, _, err = pt.Get("children[0]")
+	assert.Error(t, err)
+	_, _, err = pt.Get("friends[0].first")
+	assert.Error(t, err)
+}
+
+func TestJSONAllIncludeKeysPositional(t *testing.T) {
+	runner, err := NewTestingRunner(`json_all(_, ["age"])`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `{"name": "Tom", "age": 37}`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	got, _, err := pt.Get("age")
+	assert.NoError(t, err)
+	assert.Equal(t, float64(37), got)
+
+	_, _, err = pt.Get("name")
+	assert.Error(t, err)
+}
+
+func TestJSONAllKeyPatterns(t *testing.T) {
+	runner, err := NewTestingRunner(`json_all(
+		_,
+		include_keys=["trace_*"],
+		key_patterns=["trace_?d"],
+	)`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `{
+			"trace_*": "literal",
+			"trace_id": "abc",
+			"trace_span": "def",
+			"service": "api"
+		}`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	got, _, err := pt.Get("trace_*")
+	assert.NoError(t, err)
+	assert.Equal(t, "literal", got)
+
+	got, _, err = pt.Get("trace_id")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", got)
+
+	_, _, err = pt.Get("trace_span")
+	assert.Error(t, err)
+	_, _, err = pt.Get("service")
+	assert.Error(t, err)
+}
+
+func TestJSONAllWithoutKeysDoesNothing(t *testing.T) {
+	runner, err := NewTestingRunner(`json_all(_)`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `{"name": "Tom", "age": 37}`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	for _, key := range []string{"name", "age"} {
+		_, _, err := pt.Get(key)
+		assert.Error(t, err)
+	}
+}
+
+func TestJSONAllDynamicIncludeKeys(t *testing.T) {
+	runner, err := NewTestingRunner(`
+keys = ["service", "status", "name.first"]
+json_all(_, include_keys=keys)
+`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `{"service": "api", "status": "ok", "name": {"first": "Tom", "last": "Anderson"}, "age": 37}`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	got, _, err := pt.Get("service")
+	assert.NoError(t, err)
+	assert.Equal(t, "api", got)
+
+	got, _, err = pt.Get("status")
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", got)
+
+	_, _, err = pt.Get("name.first")
+	assert.Error(t, err)
+	_, _, err = pt.Get("age")
+	assert.Error(t, err)
+}
+
+func TestJSONAllTopLevelArray(t *testing.T) {
+	runner, err := NewTestingRunner(`json_all(_, include_keys=["[0]", "[1]", "[2].name"])`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `["first", 2, {"name": "nested"}]`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	got, _, err := pt.Get("[0]")
+	assert.NoError(t, err)
+	assert.Equal(t, "first", got)
+
+	got, _, err = pt.Get("[1]")
+	assert.NoError(t, err)
+	assert.Equal(t, float64(2), got)
+
+	_, _, err = pt.Get("[2]")
+	assert.Error(t, err)
+	_, _, err = pt.Get("[2].name")
+	assert.Error(t, err)
+}
+
+func TestJSONAllEmptyIncludeKeys(t *testing.T) {
+	runner, err := NewTestingRunner(`json_all(_, include_keys=[])`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{
+		"message": `{"name": "Tom", "age": 37}`,
+	}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	_, _, err = pt.Get("name")
+	assert.Error(t, err)
+	_, _, err = pt.Get("age")
+	assert.Error(t, err)
+}
+
+func TestJSONAllChecking(t *testing.T) {
+	_, err := NewTestingRunner(`json_all()`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(include_keys=["age"])`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(["age"])`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(_, limit=3)`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(_, include_keys=[1])`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(_, key_patterns=[1])`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(_, include_keys="age")`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`json_all(_, key_patterns="trace_*")`)
+	assert.Error(t, err)
+}

--- a/ptinput/funcs/fn_pt_kvs.go
+++ b/ptinput/funcs/fn_pt_kvs.go
@@ -2,6 +2,10 @@ package funcs
 
 import (
 	_ "embed"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/GuanceCloud/cliutils/point"
 	"github.com/GuanceCloud/pipeline-go/ptinput"
@@ -36,9 +40,16 @@ var (
 	//go:embed md/pt_kvs_keys.en.md
 	docPtKvsKeysEN string
 
+	//go:embed md/pt_kvs_set_map.md
+	docPtKvsSetMap string
+
+	//go:embed md/pt_kvs_set_map.en.md
+	docPtKvsSetMapEN string
+
 	// todo: parse function definition
 	_ = "fn pt_kvs_get(name: str, raw: bool = false) -> any"
 	_ = "fn pt_kvs_set(name: str, value: any, as_tag: bool = false, raw: bool = false) -> bool"
+	_ = "fn pt_kvs_set_map(values: map, include_keys: list|nil = nil, key_patterns: list|nil = nil, as_tag: bool = false, raw: bool = false) -> int"
 	_ = "fn pt_kvs_del(name: str)"
 	_ = "fn pt_kvs_keys(tags: bool = true, fields: bool = true) -> list"
 
@@ -120,6 +131,8 @@ var (
 		ptKvsSet,
 	)
 
+	FnPtKvsSetMap = newPtKvsSetMapFunc()
+
 	FnPtKvsDel = NewFunc(
 		"pt_kvs_del",
 		[]*Param{
@@ -181,6 +194,76 @@ var (
 	)
 )
 
+func newPtKvsSetMapFunc() *Function {
+	params := []*Param{
+		{
+			Name: "values",
+			Type: []ast.DType{ast.Map},
+		},
+		{
+			Name:     "include_keys",
+			Type:     []ast.DType{ast.List, ast.Nil},
+			Optional: true,
+			DefaultVal: func() (any, ast.DType) {
+				return nil, ast.Nil
+			},
+		},
+		{
+			Name:     "key_patterns",
+			Type:     []ast.DType{ast.List, ast.Nil},
+			Optional: true,
+			DefaultVal: func() (any, ast.DType) {
+				return nil, ast.Nil
+			},
+		},
+		{
+			Name:     "as_tag",
+			Type:     []ast.DType{ast.Bool},
+			Optional: true,
+			DefaultVal: func() (any, ast.DType) {
+				return false, ast.Bool
+			},
+		},
+		{
+			Name:     "raw",
+			Type:     []ast.DType{ast.Bool},
+			Optional: true,
+			DefaultVal: func() (any, ast.DType) {
+				return false, ast.Bool
+			},
+		},
+	}
+
+	fn := NewFunc(
+		"pt_kvs_set_map",
+		params,
+		[]ast.DType{ast.Int},
+		[2]*PLDoc{
+			{
+				Language: langTagZhCN, Doc: docPtKvsSetMap,
+				FnCategory: map[string][]string{
+					langTagZhCN: {cPointOp}},
+			},
+			{
+				Language: langTagEnUS, Doc: docPtKvsSetMapEN,
+				FnCategory: map[string][]string{
+					langTagEnUS: {ePointOp}},
+			},
+		},
+		ptKvsSetMap,
+	)
+
+	baseCheck := fn.Check
+	fn.Check = func(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
+		if err := baseCheck(ctx, funcExpr); err != nil {
+			return err
+		}
+		return ptKvsSetMapChecking(ctx, funcExpr)
+	}
+
+	return fn
+}
+
 func ptKvsGet(ctx *runtime.Task, funcExpr *ast.CallExpr, vals ...any) *errchain.PlError {
 	var (
 		val   any
@@ -215,28 +298,212 @@ func ptKvsSet(ctx *runtime.Task, funcExpr *ast.CallExpr, vals ...any) *errchain.
 		return nil
 	}
 
-	if asTag {
-		if ok := pt.SetTag(name, val, getValDtype(val)); !ok {
-			ctx.Regs.ReturnAppend(false, ast.Bool)
-			return nil
-		}
-	} else {
-		dtype := getValDtype(val)
-		if !raw && (dtype == ast.List || dtype == ast.Map) {
-			if s, err := ptinput.Conv2String(val, dtype); err == nil {
-				val = s
-				dtype = ast.String
-			}
-		}
-
-		if ok := pt.Set(name, val, dtype); !ok {
-			ctx.Regs.ReturnAppend(false, ast.Bool)
-			return nil
-		}
+	if ok := ptKvsSetValue(pt, name, val, asTag, raw); !ok {
+		ctx.Regs.ReturnAppend(false, ast.Bool)
+		return nil
 	}
 
 	ctx.Regs.ReturnAppend(true, ast.Bool)
 	return nil
+}
+
+func ptKvsSetMapChecking(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
+	includeKeys := ptKvsFuncArgValueNode(funcExpr.Param[1])
+	if includeKeys != nil && includeKeys.NodeType == ast.TypeListLiteral {
+		if _, err := ptKvsStringListFromListLiteral(includeKeys, "include_keys"); err != nil {
+			return runtime.NewRunError(ctx, err.Error(), includeKeys.StartPos())
+		}
+	}
+
+	keyPatterns := ptKvsFuncArgValueNode(funcExpr.Param[2])
+	if keyPatterns != nil && keyPatterns.NodeType == ast.TypeListLiteral {
+		if _, err := ptKvsPatternMatchersFromListLiteral(keyPatterns); err != nil {
+			return runtime.NewRunError(ctx, err.Error(), keyPatterns.StartPos())
+		}
+	}
+
+	return nil
+}
+
+func ptKvsFuncArgValueNode(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	if node.NodeType == ast.TypeAssignmentExpr {
+		expr := node.AssignmentExpr()
+		if len(expr.RHS) > 0 {
+			return expr.RHS[0]
+		}
+	}
+	return node
+}
+
+func ptKvsSetMap(ctx *runtime.Task, funcExpr *ast.CallExpr, vals ...any) *errchain.PlError {
+	values, _ := vals[0].(map[string]any)
+	includeKeys := vals[1]
+	keyPatterns := vals[2]
+	asTag := vals[3].(bool)
+	raw := vals[4].(bool)
+
+	exactKeys, filterExact, err := ptKvsExactKeySet(includeKeys)
+	if err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[1].StartPos())
+	}
+
+	patterns, filterPatterns, err := ptKvsPatternMatchers(keyPatterns)
+	if err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[2].StartPos())
+	}
+
+	if !filterExact && !filterPatterns {
+		ctx.Regs.ReturnAppend(int64(0), ast.Int)
+		return nil
+	}
+
+	pt, errPt := getPoint(ctx.InData())
+	if errPt != nil {
+		ctx.Regs.ReturnAppend(int64(0), ast.Int)
+		return nil
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var count int64
+	for _, key := range keys {
+		if !ptKvsKeyMatched(key, exactKeys, patterns) {
+			continue
+		}
+		if ok := ptKvsSetValue(pt, key, values[key], asTag, raw); ok {
+			count++
+		}
+	}
+
+	ctx.Regs.ReturnAppend(count, ast.Int)
+	return nil
+}
+
+func ptKvsSetValue(pt ptinput.PlInputPt, name string, val any, asTag, raw bool) bool {
+	if asTag {
+		return pt.SetTag(name, val, getValDtype(val))
+	}
+
+	dtype := getValDtype(val)
+	if !raw && (dtype == ast.List || dtype == ast.Map) {
+		if s, err := ptinput.Conv2String(val, dtype); err == nil {
+			val = s
+			dtype = ast.String
+		}
+	}
+
+	return pt.Set(name, val, dtype)
+}
+
+func ptKvsExactKeySet(v any) (map[string]struct{}, bool, error) {
+	keys, provided, err := ptKvsStringList(v, "include_keys")
+	if err != nil || !provided {
+		return nil, provided, err
+	}
+
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		set[key] = struct{}{}
+	}
+	return set, true, nil
+}
+
+func ptKvsPatternMatchers(v any) ([]*regexp.Regexp, bool, error) {
+	patterns, provided, err := ptKvsStringList(v, "key_patterns")
+	if err != nil || !provided {
+		return nil, provided, err
+	}
+
+	return ptKvsCompilePatterns(patterns)
+}
+
+func ptKvsStringList(v any, paramName string) ([]string, bool, error) {
+	if v == nil {
+		return nil, false, nil
+	}
+
+	values, ok := v.([]any)
+	if !ok {
+		return nil, false, fmt.Errorf("param %s expect list", paramName)
+	}
+
+	keys := make([]string, 0, len(values))
+	for _, key := range values {
+		keyStr, ok := key.(string)
+		if !ok {
+			return nil, true, fmt.Errorf("param %s element expect string", paramName)
+		}
+		keys = append(keys, keyStr)
+	}
+
+	return keys, true, nil
+}
+
+func ptKvsStringListFromListLiteral(node *ast.Node, paramName string) ([]string, error) {
+	keys := make([]string, 0, len(node.ListLiteral().List))
+	for _, elem := range node.ListLiteral().List {
+		if elem.NodeType != ast.TypeStringLiteral {
+			return nil, fmt.Errorf("param %s element expect StringLiteral, got %s",
+				paramName, elem.NodeType)
+		}
+		keys = append(keys, elem.StringLiteral().Val)
+	}
+	return keys, nil
+}
+
+func ptKvsPatternMatchersFromListLiteral(node *ast.Node) ([]*regexp.Regexp, error) {
+	patterns, err := ptKvsStringListFromListLiteral(node, "key_patterns")
+	if err != nil {
+		return nil, err
+	}
+	matchers, _, err := ptKvsCompilePatterns(patterns)
+	return matchers, err
+}
+
+func ptKvsCompilePatterns(patterns []string) ([]*regexp.Regexp, bool, error) {
+	matchers := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		re, err := regexp.Compile("^" + ptKvsWildcardToRegexp(pattern) + "$")
+		if err != nil {
+			return nil, true, err
+		}
+		matchers = append(matchers, re)
+	}
+	return matchers, true, nil
+}
+
+func ptKvsKeyMatched(key string, exactKeys map[string]struct{}, patterns []*regexp.Regexp) bool {
+	if _, ok := exactKeys[key]; ok {
+		return true
+	}
+	for _, pattern := range patterns {
+		if pattern.MatchString(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func ptKvsWildcardToRegexp(pattern string) string {
+	var b strings.Builder
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			b.WriteString(".*")
+		case '?':
+			b.WriteByte('.')
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	return b.String()
 }
 
 func ptKvsDel(ctx *runtime.Task, funcExpr *ast.CallExpr, vals ...any) *errchain.PlError {

--- a/ptinput/funcs/fn_pt_kvs_test.go
+++ b/ptinput/funcs/fn_pt_kvs_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/GuanceCloud/cliutils/point"
 	"github.com/GuanceCloud/pipeline-go/ptinput"
+	"github.com/GuanceCloud/platypus/pkg/ast"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -257,6 +258,142 @@ func TestPtKvsSet(t *testing.T) {
 
 		})
 	}
+}
+
+func TestPtKvsSetMapIncludeKeysAndWildcard(t *testing.T) {
+	runner, err := NewTestingRunner(`
+fields = {
+	"service": "api",
+	"status": 200,
+	"trace_id": "abc",
+	"trace_span": "def",
+	"literal_*": "literal",
+	"drop": "x",
+}
+count = pt_kvs_set_map(fields, include_keys=["literal_*", "service"], key_patterns=["trace_*"])
+pt_kvs_set("count", count)
+`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": "test"}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	v, _, err := pt.Get("service")
+	assert.NoError(t, err)
+	assert.Equal(t, "api", v)
+
+	v, _, err = pt.Get("trace_id")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", v)
+
+	v, _, err = pt.Get("literal_*")
+	assert.NoError(t, err)
+	assert.Equal(t, "literal", v)
+
+	v, _, err = pt.Get("count")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), v)
+
+	v, _, err = pt.Get("trace_span")
+	assert.NoError(t, err)
+	assert.Equal(t, "def", v)
+
+	_, _, err = pt.Get("drop")
+	assert.Error(t, err)
+}
+
+func TestPtKvsSetMapWithoutKeysDoesNothing(t *testing.T) {
+	runner, err := NewTestingRunner(`
+fields = {"c": 3, "a": 1, "b": 2}
+count = pt_kvs_set_map(fields)
+pt_kvs_set("count", count)
+`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": "test"}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	for _, key := range []string{"a", "b", "c"} {
+		_, _, err := pt.Get(key)
+		assert.Error(t, err)
+	}
+
+	v, _, err := pt.Get("count")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), v)
+}
+
+func TestPtKvsSetMapEmptyIncludeKeys(t *testing.T) {
+	runner, err := NewTestingRunner(`
+fields = {"a": 1}
+count = pt_kvs_set_map(fields, include_keys=[])
+pt_kvs_set("count", count)
+`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": "test"}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	_, _, err = pt.Get("a")
+	assert.Error(t, err)
+
+	v, _, err := pt.Get("count")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), v)
+}
+
+func TestPtKvsSetMapRawAndTag(t *testing.T) {
+	runner, err := NewTestingRunner(`
+fields = {"obj": {"a": 1}, "nums": [1, 2], "tag": 3}
+pt_kvs_set_map(fields, include_keys=["obj", "nums"], raw=true)
+pt_kvs_set_map(fields, include_keys=["tag"], as_tag=true)
+`)
+	assert.NoError(t, err)
+
+	pt := ptinput.NewPlPt(
+		point.Logging, "test", nil, map[string]any{"message": "test"}, time.Now())
+	errR := runScript(runner, pt)
+	if errR != nil {
+		t.Fatal(errR.Error())
+	}
+
+	v, dt, err := pt.GetRaw("obj")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.Map, dt)
+	assert.Equal(t, map[string]any{"a": int64(1)}, v)
+
+	v, dt, err = pt.GetRaw("nums")
+	assert.NoError(t, err)
+	assert.Equal(t, ast.List, dt)
+	assert.Equal(t, []any{int64(1), int64(2)}, v)
+
+	v, _, err = pt.Get("tag")
+	assert.NoError(t, err)
+	assert.Equal(t, "3", v)
+	assert.Equal(t, "3", pt.Tags()["tag"])
+}
+
+func TestPtKvsSetMapChecking(t *testing.T) {
+	_, err := NewTestingRunner(`pt_kvs_set_map({"a": 1}, include_keys=[1])`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`pt_kvs_set_map({"a": 1}, key_patterns=[1])`)
+	assert.Error(t, err)
+
+	_, err = NewTestingRunner(`pt_kvs_set_map({"a": 1}, limit=1)`)
+	assert.Error(t, err)
 }
 
 func TestPtKvsGetComposite(t *testing.T) {

--- a/ptinput/funcs/funcs_b_test.go
+++ b/ptinput/funcs/funcs_b_test.go
@@ -606,7 +606,7 @@ func TestJsonAllFunc(t *testing.T) {
 			    {"first": "Jane", "last": "Murphy", "age": 47, "nets": ["ig", "tw"]}
 			  ]
 			}`,
-			script:   `json_all()`,
+			script:   `json_all(_)`,
 			expected: "Sara",
 			key:      "children[0]",
 		},
@@ -616,7 +616,7 @@ func TestJsonAllFunc(t *testing.T) {
 			    {"first": "Roger", "last": "Craig", "age": 68, "nets": ["fb", "tw"]},
 			    {"first": "Jane", "last": "Murphy", "age": 47, "nets": ["ig", "tw"]}
 			  ]`,
-			script:   `json_all()`,
+			script:   `json_all(_)`,
 			expected: "Dale",
 			key:      "[0].first",
 		},
@@ -647,7 +647,7 @@ func TestJsonAllFunc(t *testing.T) {
   ]
 }
 `
-	script := `json_all()`
+	script := `json_all(_)`
 
 	p, err := NewPipeline(script)
 	assertEqual(t, err, nil)

--- a/ptinput/funcs/md/json_all.en.md
+++ b/ptinput/funcs/md/json_all.en.md
@@ -1,0 +1,53 @@
+### `json_all()` {#fn-json-all}
+
+Function prototype: `fn json_all(input, include_keys: list = nil, key_patterns: list = nil)`
+
+Function description: Extract top-level scalar fields from JSON and write them to the current Point by top-level key.
+
+Function parameters:
+
+- `input`: The JSON to expand. It can be the original text (`_`) or an extracted key
+- `include_keys`: Extract only the specified top-level keys. Keys must match exactly
+- `key_patterns`: Extract only top-level keys that match wildcard patterns. `*` and `?` are supported
+
+Notes:
+
+- Only top-level strings, numbers, and booleans are written. Top-level objects, arrays, and `null` are not written as fields
+- Object fields and array elements are not expanded recursively, so `name.first` and `children[0]` are not extracted
+- Top-level scalar array elements can be matched with `[index]`; array elements that are objects or arrays are not expanded
+- `include_keys` uses exact matching. Use `key_patterns` for wildcard matching
+- When both `include_keys` and `key_patterns` are empty or omitted, no fields are extracted
+
+Example:
+
+```python
+# input data:
+# {
+#   "service": "api",
+#   "name": {"first": "Tom", "last": "Anderson"},
+#   "age": 37,
+#   "trace_id": "abc"
+# }
+
+# script:
+json_all(_, include_keys=["service", "age"], key_patterns=["trace_*"])
+
+# result contains:
+# {
+#   "service": "api",
+#   "age": 37,
+#   "trace_id": "abc"
+# }
+```
+
+Filter by exact path:
+
+```python
+json_all(_, include_keys=["service", "age"])
+```
+
+Filter by wildcard:
+
+```python
+json_all(_, key_patterns=["trace_*"])
+```

--- a/ptinput/funcs/md/json_all.md
+++ b/ptinput/funcs/md/json_all.md
@@ -1,0 +1,53 @@
+### `json_all()` {#fn-json-all}
+
+函数原型：`fn json_all(input, include_keys: list = nil, key_patterns: list = nil)`
+
+函数说明：提取 JSON 顶层的标量字段，并按顶层 key 写入当前 Point。
+
+函数参数：
+
+- `input`: 待展开的 JSON，可以是原始文本（`_`）或已经提取出的某个 key
+- `include_keys`: 只提取指定顶层 key，key 需要完整匹配
+- `key_patterns`: 只提取匹配通配符的顶层 key，支持 `*` 和 `?`
+
+说明：
+
+- 只写入顶层字符串、数字、布尔值；顶层对象、数组和 `null` 不会作为字段写入
+- 不会递归展开对象字段或数组元素，例如 `name.first` 和 `children[0]` 不会被提取
+- 顶层数组中的标量元素可通过 `[index]` 匹配；数组元素如果是对象或数组则不会继续展开
+- `include_keys` 是精确匹配；如果需要通配符匹配，请使用 `key_patterns`
+- `include_keys` 和 `key_patterns` 均为空或未传时，不提取任何字段
+
+示例：
+
+```python
+# 待处理数据：
+# {
+#   "service": "api",
+#   "name": {"first": "Tom", "last": "Anderson"},
+#   "age": 37,
+#   "trace_id": "abc"
+# }
+
+# 处理脚本：
+json_all(_, include_keys=["service", "age"], key_patterns=["trace_*"])
+
+# 处理结果包含：
+# {
+#   "service": "api",
+#   "age": 37,
+#   "trace_id": "abc"
+# }
+```
+
+按路径筛选：
+
+```python
+json_all(_, include_keys=["service", "age"])
+```
+
+按通配符筛选：
+
+```python
+json_all(_, key_patterns=["trace_*"])
+```

--- a/ptinput/funcs/md/pt_kvs_set_map.en.md
+++ b/ptinput/funcs/md/pt_kvs_set_map.en.md
@@ -1,0 +1,35 @@
+### `pt_kvs_set_map()` {#fn_pt_kvs_set_map}
+
+Function prototype: `fn pt_kvs_set_map(values: map, include_keys: list|nil = nil, key_patterns: list|nil = nil, as_tag: bool = false, raw: bool = false) -> int`
+
+Function description: Extract key/value pairs from a map and write them into the Point in batch. The return value is the number of keys written.
+
+Notes:
+
+- When both `include_keys` and `key_patterns` are empty or omitted, no keys are written
+- `include_keys` matches exact keys only
+- `key_patterns` supports `*` / `?` wildcard patterns
+- By default, `list` / `map` field values are written as strings
+- With `raw=true`, field values prefer native Point array/dict storage
+- When setting tags, values are converted to strings
+
+Parameters:
+
+- `values`: map to write into the Point
+- `include_keys`: exact key list to extract
+- `key_patterns`: wildcard patterns to extract; supports `*` and `?`
+- `as_tag`: whether to write values as tags
+- `raw`: whether to preserve native Point array/dict values when writing fields
+
+Example:
+
+```python
+fields = {
+    "service": "api",
+    "status": 200,
+    "trace_id": "abc",
+    "trace_span": "def",
+}
+
+count = pt_kvs_set_map(fields, include_keys=["service"], key_patterns=["trace_*"])
+```

--- a/ptinput/funcs/md/pt_kvs_set_map.md
+++ b/ptinput/funcs/md/pt_kvs_set_map.md
@@ -1,0 +1,35 @@
+### `pt_kvs_set_map()` {#fn_pt_kvs_set_map}
+
+函数原型：`fn pt_kvs_set_map(values: map, include_keys: list|nil = nil, key_patterns: list|nil = nil, as_tag: bool = false, raw: bool = false) -> int`
+
+函数说明：从 map 中批量提取 key/value 并写入 Point，返回成功写入的数量。
+
+说明：
+
+- `include_keys` 和 `key_patterns` 均为空或未传时，不写入任何 key
+- `include_keys` 中的元素只按精确 key 匹配
+- `key_patterns` 中的元素支持 `*` 和 `?` 通配
+- 默认设置 field 时，`list` / `map` 会写成字符串
+- 传入 `raw=true` 时，设置 field 会优先保留 Point 原生数组/字典
+- 设置 tag 时，值会转换为字符串
+
+函数参数：
+
+- `values`: 待写入 Point 的 map
+- `include_keys`: 待提取的精确 key 列表
+- `key_patterns`: 待提取的 key 通配模式列表；支持 `*` 和 `?`
+- `as_tag`: 是否设置为标签
+- `raw`: 设置 field 时是否保留 Point 原生数组/字典
+
+示例：
+
+```python
+fields = {
+    "service": "api",
+    "status": 200,
+    "trace_id": "abc",
+    "trace_span": "def",
+}
+
+count = pt_kvs_set_map(fields, include_keys=["service"], key_patterns=["trace_*"])
+```


### PR DESCRIPTION
## Summary

- Enable `json_all` as a documented pipeline function and remove its disabled/test-skip treatment.
- Add `pt_kvs_set_map` for filtered bulk map writes into points.
- Make both helpers whitelist-driven: no `include_keys` or `key_patterns` means no extraction/writes, and neither helper accepts `limit`.
- Limit `json_all` extraction to top-level scalar JSON fields, with docs and tests for exact keys, wildcard patterns, top-level arrays, and invalid calls.

## Validation

- `go test -count=1 ./ptinput/funcs ./internal/command/pipelinecheck`
- `go run ./cmd/pipeline-go pipeline check --search-functions json_all --function-lang all`
- `go run ./cmd/pipeline-go pipeline check --search-functions pt_kvs_set_map --function-lang all`
- `git diff --check`

## Notes

Full `go test -count=1 ./...` still fails in the pre-existing `pkg/arbiter/request` host filter tests (`TestHostFilte/test4` and `test5`), unrelated to these pipeline function changes.
