### PR TITLE
feat: support prefixes for generated function fields

### DIFF
--- a/ptinput/funcs/fn_geo_ip.go
+++ b/ptinput/funcs/fn_geo_ip.go
@@ -31,26 +31,46 @@ var geoDefaultVal = "unknown"
 // }
 
 func GeoIPChecking(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	if len(funcExpr.Param) != 1 {
-		return runtime.NewRunError(ctx, fmt.Sprintf(
-			"func `%s' expected 1 args", funcExpr.Name), funcExpr.NamePos)
+	if err := normalizeFuncArgsDeprecated(funcExpr, []string{
+		"ip", "prefix",
+	}, 1); err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.NamePos)
 	}
 
 	if _, err := getKeyName(funcExpr.Param[0]); err != nil {
 		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
 	}
 
+	if funcExpr.Param[1] != nil {
+		switch funcExpr.Param[1].NodeType { //nolint:exhaustive
+		case ast.TypeIdentifier, ast.TypeStringLiteral, ast.TypeAttrExpr:
+		default:
+			return runtime.NewRunError(ctx, fmt.Sprintf(
+				"expect StringLiteral or Identifier or AttrExpr, got %s",
+				funcExpr.Param[1].NodeType), funcExpr.Param[1].StartPos())
+		}
+	}
+
 	return nil
 }
 
 func GeoIP(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	if len(funcExpr.Param) != 1 {
-		return runtime.NewRunError(ctx, fmt.Sprintf(
-			"func `%s' expected 1 args", funcExpr.Name), funcExpr.NamePos)
-	}
 	key, err := getKeyName(funcExpr.Param[0])
 	if err != nil {
 		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
+	}
+
+	prefix := ""
+	if funcExpr.Param[1] != nil {
+		prefixVal, dtype, errR := runtime.RunStmt(ctx, funcExpr.Param[1])
+		if errR != nil {
+			return errR
+		}
+		if dtype != ast.String {
+			return runtime.NewRunError(ctx, "param data type expect string",
+				funcExpr.Param[1].StartPos())
+		}
+		prefix = prefixVal.(string)
 	}
 
 	ipStr, err := ctx.GetKeyConv2Str(key)
@@ -69,7 +89,7 @@ func GeoIP(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 		return nil
 	} else {
 		for k, v := range dic {
-			_ = addKey2PtWithVal(ctx.InData(), k, v, ast.String, ptinput.KindPtDefault)
+			_ = addKey2PtWithVal(ctx.InData(), prefix+k, v, ast.String, ptinput.KindPtDefault)
 		}
 	}
 

--- a/ptinput/funcs/fn_gep_ip_test.go
+++ b/ptinput/funcs/fn_gep_ip_test.go
@@ -124,6 +124,84 @@ func TestGeoIpFunc(t *testing.T) {
 				"isp":      geoDefaultVal,
 			},
 		},
+
+		{
+			in: `{"ip":"1.2.3.4-something", "second":2,"third":"abc","forth":true}`,
+			script: `
+				json(_, ip)
+				geoip(ip, "geo_")`,
+			expected: map[string]string{
+				"geo_city":     "Shanghai",
+				"geo_country":  "CN",
+				"geo_province": "Shanghai",
+				"geo_isp":      geoDefaultVal,
+			},
+		},
+		{
+			in: `{"ip":"1.2.3.4-something", "second":2,"third":"abc","forth":true}`,
+			script: `
+				json(_, ip)
+				p = "geo_"
+				geoip(ip, p)`,
+			expected: map[string]string{
+				"geo_city":     "Shanghai",
+				"geo_country":  "CN",
+				"geo_province": "Shanghai",
+				"geo_isp":      geoDefaultVal,
+			},
+		},
+		{
+			in: `{"ip":"1.2.3.4-something", "second":2,"third":"abc","forth":true}`,
+			script: `
+				json(_, ip)
+				geoip(ip, prefix="geo_")`,
+			expected: map[string]string{
+				"geo_city":     "Shanghai",
+				"geo_country":  "CN",
+				"geo_province": "Shanghai",
+				"geo_isp":      geoDefaultVal,
+			},
+		},
+		{
+			in: `{"ip":"1.2.3.4-something", "second":2,"third":"abc","forth":true}`,
+			script: `
+				json(_, ip)
+				geoip(ip, "")`,
+			expected: map[string]string{
+				"city":     "Shanghai",
+				"country":  "CN",
+				"province": "Shanghai",
+				"isp":      geoDefaultVal,
+			},
+		},
+		{
+			in: `{"second":2,"third":"abc","forth":true}`,
+			script: `
+				geoip(ip, "geo_")`,
+			expected: map[string]string{},
+		},
+		{
+			in: `{"ip":"1.2.3.4-something"}`,
+			script: `
+				json(_, ip)
+				geoip(ip, 2)`,
+			fail: true,
+		},
+		{
+			in: `{"ip":"1.2.3.4-something"}`,
+			script: `
+				json(_, ip)
+				p = 123
+				geoip(ip, p)`,
+			fail: true,
+		},
+		{
+			in: `{"ip":"1.2.3.4-something"}`,
+			script: `
+				json(_, ip)
+				geoip(ip, "a", "b")`,
+			fail: true,
+		},
 	}
 
 	for idx, tc := range cases {
@@ -131,8 +209,10 @@ func TestGeoIpFunc(t *testing.T) {
 
 		runner, err := NewTestingRunner(tc.script)
 		if err != nil {
-			t.Errorf("[%d] failed: %s", idx, err)
-			return
+			if !tc.fail {
+				t.Fatalf("[%d] unexpected compile error: %s", idx, err)
+			}
+			continue
 		}
 
 		pt := ptinput.NewPlPt(
@@ -141,7 +221,14 @@ func TestGeoIpFunc(t *testing.T) {
 		errR := runScript(runner, pt)
 
 		if errR != nil {
-			t.Fatal(errR.Error())
+			if !tc.fail {
+				t.Fatalf("[%d] unexpected runtime error: %s", idx, errR)
+			}
+			continue
+		}
+		if tc.fail {
+			t.Errorf("[%d] expected an error, got nil", idx)
+			continue
 		}
 
 		for k, v := range tc.expected {

--- a/ptinput/funcs/fn_gep_ip_test.go
+++ b/ptinput/funcs/fn_gep_ip_test.go
@@ -57,6 +57,7 @@ func TestGeoIpFunc(t *testing.T) {
 		script string
 
 		expected map[string]string
+		absent   []string
 
 		fail bool
 	}{
@@ -129,13 +130,16 @@ func TestGeoIpFunc(t *testing.T) {
 			in: `{"ip":"1.2.3.4-something", "second":2,"third":"abc","forth":true}`,
 			script: `
 				json(_, ip)
+				add_key(city, "existing")
 				geoip(ip, "geo_")`,
 			expected: map[string]string{
+				"city":         "existing",
 				"geo_city":     "Shanghai",
 				"geo_country":  "CN",
 				"geo_province": "Shanghai",
 				"geo_isp":      geoDefaultVal,
 			},
+			absent: []string{"country", "province", "isp"},
 		},
 		{
 			in: `{"ip":"1.2.3.4-something", "second":2,"third":"abc","forth":true}`,
@@ -235,6 +239,10 @@ func TestGeoIpFunc(t *testing.T) {
 			r, _, e := pt.Get(k)
 			assert.NoError(t, e)
 			assert.Equal(t, v, r, "`%s` != `%s`, key: `%s`", r, v, k)
+		}
+		for _, k := range tc.absent {
+			_, _, err := pt.Get(k)
+			assert.Error(t, err, "key %q should not be generated without the prefix", k)
 		}
 	}
 }

--- a/ptinput/funcs/fn_http_request.go
+++ b/ptinput/funcs/fn_http_request.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -102,9 +103,19 @@ func filterURL(urlStr string, disable bool, cidrs, hosts []string) bool {
 
 func HTTPRequestChecking(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 	if err := normalizeFuncArgsDeprecated(funcExpr, []string{
-		"method", "url", "headers", "body",
+		"method", "url", "headers", "body", "prefix",
 	}, 2); err != nil {
 		return runtime.NewRunError(ctx, err.Error(), funcExpr.NamePos)
+	}
+
+	if funcExpr.Param[4] != nil {
+		switch funcExpr.Param[4].NodeType { //nolint:exhaustive
+		case ast.TypeIdentifier, ast.TypeStringLiteral, ast.TypeAttrExpr:
+		default:
+			return runtime.NewRunError(ctx, fmt.Sprintf(
+				"expect StringLiteral or Identifier or AttrExpr, got %s",
+				funcExpr.Param[4].NodeType), funcExpr.Param[4].StartPos())
+		}
 	}
 
 	return nil
@@ -128,6 +139,19 @@ func HTTPRequest(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 	if urlType != ast.String {
 		return runtime.NewRunError(ctx, "param data type expect string",
 			funcExpr.Param[1].StartPos())
+	}
+
+	var prefix string
+	if funcExpr.Param[4] != nil {
+		prefixVal, prefixType, errP := runtime.RunStmt(ctx, funcExpr.Param[4])
+		if errP != nil {
+			return errP
+		}
+		if prefixType != ast.String {
+			return runtime.NewRunError(ctx, "param data type expect string",
+				funcExpr.Param[4].StartPos())
+		}
+		prefix = prefixVal.(string)
 	}
 
 	if filterURL(url.(string), gDisableInternalNet, gCIDRsWhitelist, gHostWhitelist) {
@@ -191,8 +215,8 @@ func HTTPRequest(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 	}
 
 	respData := map[string]interface{}{
-		"status_code": resp.StatusCode,
-		"body":        string(body),
+		prefix + "status_code": resp.StatusCode,
+		prefix + "body":        string(body),
 	}
 	ctx.Regs.ReturnAppend(respData, ast.Map)
 

--- a/ptinput/funcs/fn_http_request_test.go
+++ b/ptinput/funcs/fn_http_request_test.go
@@ -250,16 +250,88 @@ func TestHTTPRequest(t *testing.T) {
 			outkey:   "abc",
 			expected: `{"a":"1"}`,
 		},
+		{
+			name: "legacy_required_args_only",
+			pl: fmt.Sprintf(`
+			resp = http_request("GET", %s)
+			add_key(status_code, resp["status_code"])
+			`, url),
+			in:       `[]`,
+			outkey:   "status_code",
+			expected: int64(200),
+		},
+		{
+			name: "test_prefix",
+			pl: fmt.Sprintf(`
+			resp = http_request("POST", %s, {"extraHeader": "1",
+			"extraHeader": "1"}, {"a": "1"}, "hr_")
+			add_key(abc, resp["hr_body"])
+			`, url),
+			in:       `[]`,
+			outkey:   "abc",
+			expected: `{"a":"1"}`,
+		},
+		{
+			name: "test_prefix_status_code",
+			pl: fmt.Sprintf(`
+			resp = http_request("GET", %s, {"extraHeader": "1",
+			"extraHeader": "1"}, nil, "hr_")
+			add_key(abc, resp["hr_status_code"])
+			`, url),
+			in:       `[]`,
+			outkey:   "abc",
+			expected: int64(200),
+		},
+		{
+			name: "test_prefix_variable",
+			pl: fmt.Sprintf(`
+			p = "hr_"
+			resp = http_request("POST", %s, {"extraHeader": "1",
+			"extraHeader": "1"}, {"a": "1"}, p)
+			add_key(abc, resp["hr_body"])
+			`, url),
+			in:       `[]`,
+			outkey:   "abc",
+			expected: `{"a":"1"}`,
+		},
+		{
+			name: "test_named_prefix",
+			pl: fmt.Sprintf(`
+			resp = http_request("POST", %s, {"extraHeader": "1",
+			"extraHeader": "1"}, {"a": "1"}, prefix="hr_")
+			add_key(abc, resp["hr_body"])
+			`, url),
+			in:       `[]`,
+			outkey:   "abc",
+			expected: `{"a":"1"}`,
+		},
+		{
+			name: "invalid prefix type",
+			pl: fmt.Sprintf(`
+			resp = http_request("POST", %s, {"extraHeader": "1",
+			"extraHeader": "1"}, {"a": "1"}, 123)
+			`, url),
+			in:   `[]`,
+			fail: true,
+		},
+		{
+			name: "invalid prefix type variable",
+			pl: fmt.Sprintf(`
+			p = 123
+			resp = http_request("POST", %s, {"extraHeader": "1",
+			"extraHeader": "1"}, {"a": "1"}, p)
+			`, url),
+			in:   `[]`,
+			fail: true,
+		},
 	}
 
 	for idx, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			runner, err := NewTestingRunner(tc.pl)
 			if err != nil {
-				if tc.fail {
-					t.Logf("[%d]expect error: %s", idx, err)
-				} else {
-					t.Errorf("[%d] failed: %s", idx, err)
+				if !tc.fail {
+					t.Fatalf("[%d] unexpected compile error: %s", idx, err)
 				}
 				return
 			}
@@ -268,7 +340,13 @@ func TestHTTPRequest(t *testing.T) {
 			errR := runScript(runner, pt)
 
 			if errR != nil {
-				t.Fatal(errR.Error())
+				if !tc.fail {
+					t.Fatalf("[%d] unexpected runtime error: %s", idx, errR)
+				}
+				return
+			}
+			if tc.fail {
+				t.Fatal("expected an error, got nil")
 			}
 
 			v, _, _ := pt.Get(tc.outkey)

--- a/ptinput/funcs/fn_http_request_test.go
+++ b/ptinput/funcs/fn_http_request_test.go
@@ -214,6 +214,7 @@ func TestHTTPRequest(t *testing.T) {
 	cases := []struct {
 		name, pl, in string
 		expected     interface{}
+		absent       []string
 		fail         bool
 		outkey       string
 	}{
@@ -266,10 +267,14 @@ func TestHTTPRequest(t *testing.T) {
 			resp = http_request("POST", %s, {"extraHeader": "1",
 			"extraHeader": "1"}, {"a": "1"}, "hr_")
 			add_key(abc, resp["hr_body"])
+			if resp["body"] != nil {
+				add_key(unexpected_unprefixed_key, true)
+			}
 			`, url),
 			in:       `[]`,
 			outkey:   "abc",
 			expected: `{"a":"1"}`,
+			absent:   []string{"unexpected_unprefixed_key"},
 		},
 		{
 			name: "test_prefix_status_code",
@@ -295,15 +300,18 @@ func TestHTTPRequest(t *testing.T) {
 			expected: `{"a":"1"}`,
 		},
 		{
-			name: "test_named_prefix",
+			name: "test_named_prefix_skips_optional_args",
 			pl: fmt.Sprintf(`
-			resp = http_request("POST", %s, {"extraHeader": "1",
-			"extraHeader": "1"}, {"a": "1"}, prefix="hr_")
+			resp = http_request("GET", %s, prefix="hr_")
 			add_key(abc, resp["hr_body"])
+			if resp["body"] != nil {
+				add_key(unexpected_unprefixed_key, true)
+			}
 			`, url),
 			in:       `[]`,
 			outkey:   "abc",
-			expected: `{"a":"1"}`,
+			expected: `{"a":"hello"}`,
+			absent:   []string{"unexpected_unprefixed_key"},
 		},
 		{
 			name: "invalid prefix type",
@@ -352,6 +360,10 @@ func TestHTTPRequest(t *testing.T) {
 			v, _, _ := pt.Get(tc.outkey)
 			// tu.Equals(t, nil, err)
 			assert.Equal(t, tc.expected, v)
+			for _, k := range tc.absent {
+				_, _, err := pt.Get(k)
+				assert.Error(t, err, "key %q indicates an unprefixed result entry was generated", k)
+			}
 
 			t.Logf("[%d] PASS", idx)
 		})

--- a/ptinput/funcs/fn_url_parse.go
+++ b/ptinput/funcs/fn_url_parse.go
@@ -16,22 +16,28 @@ import (
 )
 
 func URLParseChecking(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	if len(funcExpr.Param) != 1 {
-		return runtime.NewRunError(ctx, fmt.Sprintf(
-			"func %s expects 1 arg", funcExpr.Name), funcExpr.NamePos)
+	if err := normalizeFuncArgsDeprecated(funcExpr, []string{
+		"key", "prefix",
+	}, 1); err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.NamePos)
 	}
 	if funcExpr.Param[0].NodeType != ast.TypeIdentifier && funcExpr.Param[0].NodeType != ast.TypeAttrExpr {
 		return runtime.NewRunError(ctx, fmt.Sprintf(
 			"expect Identifier or AttrExpr, got %s", funcExpr.Param[0].NodeType), funcExpr.Param[0].StartPos())
 	}
+	if funcExpr.Param[1] != nil {
+		switch funcExpr.Param[1].NodeType { //nolint:exhaustive
+		case ast.TypeIdentifier, ast.TypeStringLiteral, ast.TypeAttrExpr:
+		default:
+			return runtime.NewRunError(ctx, fmt.Sprintf(
+				"expect StringLiteral or Identifier or AttrExpr, got %s",
+				funcExpr.Param[1].NodeType), funcExpr.Param[1].StartPos())
+		}
+	}
 	return nil
 }
 
 func URLParse(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	if len(funcExpr.Param) != 1 {
-		return runtime.NewRunError(ctx, fmt.Sprintf(
-			"func %s expects 1 arg", funcExpr.Name), funcExpr.NamePos)
-	}
 	if funcExpr.Param[0].NodeType != ast.TypeIdentifier && funcExpr.Param[0].NodeType != ast.TypeAttrExpr {
 		return runtime.NewRunError(ctx, fmt.Sprintf(
 			"expect Identifier or AttrExpr, got %s", funcExpr.Param[0].NodeType),
@@ -41,6 +47,20 @@ func URLParse(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 	if err != nil {
 		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
 	}
+
+	prefix := ""
+	if funcExpr.Param[1] != nil {
+		prefixVal, dtype, errR := runtime.RunStmt(ctx, funcExpr.Param[1])
+		if errR != nil {
+			return errR
+		}
+		if dtype != ast.String {
+			return runtime.NewRunError(ctx, "param data type expect string",
+				funcExpr.Param[1].StartPos())
+		}
+		prefix = prefixVal.(string)
+	}
+
 	u, err := ctx.GetKeyConv2Str(key)
 	if err != nil {
 		l.Debug(err)
@@ -58,11 +78,11 @@ func URLParse(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 		params[k] = strings.Join(vs, ",")
 	}
 	res := map[string]any{
-		"scheme": uu.Scheme,
-		"host":   uu.Host,
-		"port":   uu.Port(),
-		"path":   uu.Path,
-		"params": params,
+		prefix + "scheme": uu.Scheme,
+		prefix + "host":   uu.Host,
+		prefix + "port":   uu.Port(),
+		prefix + "path":   uu.Path,
+		prefix + "params": params,
 	}
 	ctx.Regs.ReturnAppend(res, ast.Map)
 	return nil

--- a/ptinput/funcs/fn_url_parse_test.go
+++ b/ptinput/funcs/fn_url_parse_test.go
@@ -96,20 +96,101 @@ add_key(a, m["params"]["arg2"])
 			fail:     false,
 		},
 		{
-			name: "invalid url",
+			name: "with prefix",
+			pl: `
+json(_, url)
+m = url_parse(url, "up_")
+add_key(scheme, m["up_scheme"])
+`,
+			in:       `{"url": "https://www.baidu.com"}`,
+			outKey:   "scheme",
+			expected: "https",
+			fail:     false,
+		},
+		{
+			name: "with prefix params",
+			pl: `
+json(_, url)
+m = url_parse(url, "up_")
+add_key(a, m["up_params"]["arg1"])
+`,
+			in:       `{"url": "http://127.0.0.1:9529/v1/metrics?arg1=v1&arg2=v2"}`,
+			outKey:   "a",
+			expected: "v1",
+			fail:     false,
+		},
+		{
+			name: "with prefix variable",
+			pl: `
+json(_, url)
+p = "up_"
+m = url_parse(url, p)
+add_key(scheme, m["up_scheme"])
+`,
+			in:       `{"url": "https://www.baidu.com"}`,
+			outKey:   "scheme",
+			expected: "https",
+			fail:     false,
+		},
+		{
+			name: "with named prefix",
+			pl: `
+json(_, url)
+m = url_parse(url, prefix="up_")
+add_key(scheme, m["up_scheme"])
+`,
+			in:       `{"url": "https://www.baidu.com"}`,
+			outKey:   "scheme",
+			expected: "https",
+			fail:     false,
+		},
+		{
+			name: "empty prefix",
+			pl: `
+json(_, url)
+m = url_parse(url, "")
+add_key(scheme, m["scheme"])
+`,
+			in:       `{"url": "https://www.baidu.com"}`,
+			outKey:   "scheme",
+			expected: "https",
+			fail:     false,
+		},
+		{
+			name: "relative path",
 			pl: `
 json(_, url)
 m = url_parse(url)
 add_key(p, m["path"])
 `,
-			in:   `{"url": "/var/log/datakit/log"}`,
+			in:       `{"url": "/var/log/datakit/log"}`,
+			outKey:   "p",
+			expected: "/var/log/datakit/log",
+		},
+		{
+			name: "too many args",
+			pl: `
+json(_, url)
+m = url_parse(url, "up_", 2)
+`,
+			in:   `{"url": "http://127.0.0.1:9529/v1/metrics?arg1=v1&arg2=v2"}`,
 			fail: true,
 		},
 		{
-			name: "two many args",
+			name: "invalid prefix type",
 			pl: `
 json(_, url)
 m = url_parse(url, 2)
+`,
+			in:   `{"url": "http://127.0.0.1:9529/v1/metrics?arg1=v1&arg2=v2"}`,
+			fail: true,
+		},
+		{
+			name: "invalid prefix type variable",
+			pl: `
+json(_, url)
+p = 123
+m = url_parse(url, p)
 `,
 			in:   `{"url": "http://127.0.0.1:9529/v1/metrics?arg1=v1&arg2=v2"}`,
 			fail: true,
@@ -120,10 +201,8 @@ m = url_parse(url, 2)
 		t.Run(tc.name, func(t *testing.T) {
 			runner, err := NewTestingRunner(tc.pl)
 			if err != nil {
-				if tc.fail {
-					t.Logf("[%d]expect error: %s", idx, err)
-				} else {
-					t.Errorf("[%d] failed: %s", idx, err)
+				if !tc.fail {
+					t.Fatalf("[%d] unexpected compile error: %s", idx, err)
 				}
 				return
 			}
@@ -131,13 +210,17 @@ m = url_parse(url, 2)
 			pt := ptinput.NewPlPt(point.Logging, "test", nil, map[string]any{"message": tc.in}, time.Now())
 			errR := runScript(runner, pt)
 			if errR != nil {
-				t.Fatal(errR)
+				if !tc.fail {
+					t.Fatalf("[%d] unexpected runtime error: %s", idx, errR)
+				}
+				return
+			}
+			if tc.fail {
+				t.Fatal("expected an error, got nil")
 			}
 
 			if v, istag, err := pt.Get(tc.outKey); err != nil {
-				if !tc.fail {
-					t.Errorf("[%d]key %s, error: %s", idx, tc.outKey, err)
-				}
+				t.Errorf("[%d]key %s, error: %s", idx, tc.outKey, err)
 			} else {
 				if istag != ast.String {
 					t.Errorf("key %s should be a field", tc.outKey)

--- a/ptinput/funcs/fn_url_parse_test.go
+++ b/ptinput/funcs/fn_url_parse_test.go
@@ -21,6 +21,7 @@ func TestURLParse(t *testing.T) {
 		pl, in   string
 		outKey   string
 		expected interface{}
+		absent   []string
 		fail     bool
 	}{
 		{
@@ -101,10 +102,14 @@ add_key(a, m["params"]["arg2"])
 json(_, url)
 m = url_parse(url, "up_")
 add_key(scheme, m["up_scheme"])
+if m["scheme"] != nil {
+    add_key(unexpected_unprefixed_key, true)
+}
 `,
 			in:       `{"url": "https://www.baidu.com"}`,
 			outKey:   "scheme",
 			expected: "https",
+			absent:   []string{"unexpected_unprefixed_key"},
 			fail:     false,
 		},
 		{
@@ -227,6 +232,11 @@ m = url_parse(url, p)
 				} else {
 					tu.Equals(t, tc.expected, v)
 					t.Logf("[%d] PASS", idx)
+				}
+			}
+			for _, k := range tc.absent {
+				if _, _, err := pt.Get(k); err == nil {
+					t.Errorf("key %q indicates an unprefixed result entry was generated", k)
 				}
 			}
 		})

--- a/ptinput/funcs/fn_useragent.go
+++ b/ptinput/funcs/fn_useragent.go
@@ -15,25 +15,43 @@ import (
 )
 
 func UserAgentChecking(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	if len(funcExpr.Param) != 1 {
-		return runtime.NewRunError(ctx, fmt.Sprintf(
-			"func `%s' expects 1 args", funcExpr.Name), funcExpr.NamePos)
+	if err := normalizeFuncArgsDeprecated(funcExpr, []string{
+		"key", "prefix",
+	}, 1); err != nil {
+		return runtime.NewRunError(ctx, err.Error(), funcExpr.NamePos)
 	}
 	if _, err := getKeyName(funcExpr.Param[0]); err != nil {
 		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
+	}
+	if funcExpr.Param[1] != nil {
+		switch funcExpr.Param[1].NodeType { //nolint:exhaustive
+		case ast.TypeIdentifier, ast.TypeStringLiteral, ast.TypeAttrExpr:
+		default:
+			return runtime.NewRunError(ctx, fmt.Sprintf(
+				"expect StringLiteral or Identifier or AttrExpr, got %s",
+				funcExpr.Param[1].NodeType), funcExpr.Param[1].StartPos())
+		}
 	}
 	return nil
 }
 
 func UserAgent(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
-	if len(funcExpr.Param) != 1 {
-		return runtime.NewRunError(ctx, fmt.Sprintf(
-			"func `%s' expects 1 args", funcExpr.Name), funcExpr.NamePos)
-	}
-
 	key, err := getKeyName(funcExpr.Param[0])
 	if err != nil {
 		return runtime.NewRunError(ctx, err.Error(), funcExpr.Param[0].StartPos())
+	}
+
+	prefix := ""
+	if funcExpr.Param[1] != nil {
+		prefixVal, dtype, errR := runtime.RunStmt(ctx, funcExpr.Param[1])
+		if errR != nil {
+			return errR
+		}
+		if dtype != ast.String {
+			return runtime.NewRunError(ctx, "param data type expect string",
+				funcExpr.Param[1].StartPos())
+		}
+		prefix = prefixVal.(string)
 	}
 
 	cont, err := ctx.GetKeyConv2Str(key)
@@ -46,7 +64,7 @@ func UserAgent(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 
 	for k, val := range dic {
 		if dtype, ok := dicT[k]; ok {
-			_ = addKey2PtWithVal(ctx.InData(), k, val, dtype, ptinput.KindPtDefault)
+			_ = addKey2PtWithVal(ctx.InData(), prefix+k, val, dtype, ptinput.KindPtDefault)
 		}
 	}
 

--- a/ptinput/funcs/fn_useragent_test.go
+++ b/ptinput/funcs/fn_useragent_test.go
@@ -19,6 +19,7 @@ func TestUserAgent(t *testing.T) {
 		name     string
 		pl, in   string
 		expected map[string]interface{}
+		absent   []string
 		fail     bool
 	}{
 		{
@@ -96,6 +97,7 @@ func TestUserAgent(t *testing.T) {
 		{
 			name: "with prefix",
 			pl: `json(_, userAgent)
+			add_key(os, "existing")
 			user_agent(userAgent, "ua_")`,
 			in: `
 {
@@ -106,6 +108,7 @@ func TestUserAgent(t *testing.T) {
 }
 `,
 			expected: map[string]interface{}{
+				"os":            "existing",
 				"ua_isMobile":   false,
 				"ua_isBot":      false,
 				"ua_os":         "Windows 7",
@@ -115,7 +118,8 @@ func TestUserAgent(t *testing.T) {
 				"ua_engineVer":  "537.36",
 				"ua_ua":         "Windows",
 			},
-			fail: false,
+			absent: []string{"isMobile", "isBot", "browser", "browserVer", "engine", "engineVer", "ua"},
+			fail:   false,
 		},
 
 		{
@@ -268,6 +272,11 @@ func TestUserAgent(t *testing.T) {
 				fieldsToCompare[k], _, _ = pt.Get(k)
 			}
 			tu.Equals(t, tc.expected, fieldsToCompare)
+			for _, k := range tc.absent {
+				if _, _, err := pt.Get(k); err == nil {
+					t.Errorf("key %q should not be generated without the prefix", k)
+				}
+			}
 			t.Logf("[%d] PASS", idx)
 		})
 	}

--- a/ptinput/funcs/fn_useragent_test.go
+++ b/ptinput/funcs/fn_useragent_test.go
@@ -23,7 +23,7 @@ func TestUserAgent(t *testing.T) {
 	}{
 		{
 			name: "normal",
-			pl: `json(_, userAgent) 
+			pl: `json(_, userAgent)
 			user_agent(userAgent)`,
 			in: `
 {
@@ -47,7 +47,7 @@ func TestUserAgent(t *testing.T) {
 		},
 		{
 			name: "normal",
-			pl: `json(_, userAgent) 
+			pl: `json(_, userAgent)
 			user_agent(userAgent)`,
 			in: `
 {
@@ -69,7 +69,7 @@ func TestUserAgent(t *testing.T) {
 
 		{
 			name: "normal",
-			pl: `json(_, userAgent) 
+			pl: `json(_, userAgent)
 			user_agent(agent)`,
 			in: `
 {
@@ -82,7 +82,7 @@ func TestUserAgent(t *testing.T) {
 
 		{
 			name: "invalid arg type",
-			pl: `json(_, userAgent) 
+			pl: `json(_, userAgent)
 			user_agent("userAgent")`,
 			in: `
 		{
@@ -94,9 +94,143 @@ func TestUserAgent(t *testing.T) {
 		},
 
 		{
+			name: "with prefix",
+			pl: `json(_, userAgent)
+			user_agent(userAgent, "ua_")`,
+			in: `
+{
+   "userAgent" : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36",
+   "second"    : 2,
+   "third"     : "abc",
+   "forth"     : true
+}
+`,
+			expected: map[string]interface{}{
+				"ua_isMobile":   false,
+				"ua_isBot":      false,
+				"ua_os":         "Windows 7",
+				"ua_browser":    "Chrome",
+				"ua_browserVer": "36.0.1985.125",
+				"ua_engine":     "AppleWebKit",
+				"ua_engineVer":  "537.36",
+				"ua_ua":         "Windows",
+			},
+			fail: false,
+		},
+
+		{
+			name: "with prefix variable",
+			pl: `json(_, userAgent)
+			p = "ua_"
+			user_agent(userAgent, p)`,
+			in: `
+{
+   "userAgent" : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36",
+   "second"    : 2,
+   "third"     : "abc",
+   "forth"     : true
+}
+`,
+			expected: map[string]interface{}{
+				"ua_isMobile":   false,
+				"ua_isBot":      false,
+				"ua_os":         "Windows 7",
+				"ua_browser":    "Chrome",
+				"ua_browserVer": "36.0.1985.125",
+				"ua_engine":     "AppleWebKit",
+				"ua_engineVer":  "537.36",
+				"ua_ua":         "Windows",
+			},
+			fail: false,
+		},
+
+		{
+			name: "with named prefix",
+			pl: `json(_, userAgent)
+			user_agent(userAgent, prefix="ua_")`,
+			in: `
+{
+   "userAgent" : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36",
+   "second"    : 2,
+   "third"     : "abc",
+   "forth"     : true
+}
+`,
+			expected: map[string]interface{}{
+				"ua_isMobile":   false,
+				"ua_isBot":      false,
+				"ua_os":         "Windows 7",
+				"ua_browser":    "Chrome",
+				"ua_browserVer": "36.0.1985.125",
+				"ua_engine":     "AppleWebKit",
+				"ua_engineVer":  "537.36",
+				"ua_ua":         "Windows",
+			},
+			fail: false,
+		},
+
+		{
+			name: "empty prefix",
+			pl: `json(_, userAgent)
+			user_agent(userAgent, "")`,
+			in: `
+{
+   "userAgent" : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36",
+   "second"    : 2,
+   "third"     : "abc",
+   "forth"     : true
+}
+`,
+			expected: map[string]interface{}{
+				"isMobile":   false,
+				"isBot":      false,
+				"os":         "Windows 7",
+				"browser":    "Chrome",
+				"browserVer": "36.0.1985.125",
+				"engine":     "AppleWebKit",
+				"engineVer":  "537.36",
+				"ua":         "Windows",
+			},
+			fail: false,
+		},
+
+		{
+			name:     "missing key with prefix",
+			pl:       `user_agent(agent, "ua_")`,
+			in:       `{}`,
+			expected: map[string]interface{}{},
+			fail:     false,
+		},
+
+		{
+			name: "invalid prefix type",
+			pl: `json(_, userAgent)
+			user_agent(userAgent, 123)`,
+			in: `
+{
+   "userAgent" : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36"
+}
+`,
+			fail: true,
+		},
+
+		{
+			name: "invalid prefix type variable",
+			pl: `json(_, userAgent)
+			p = 123
+			user_agent(userAgent, p)`,
+			in: `
+{
+   "userAgent" : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36"
+}
+`,
+			fail: true,
+		},
+
+		{
 			name: "too many args",
-			pl: `json(_, userAgent) 
-			user_agent(userAgent, someArg)`,
+			pl: `json(_, userAgent)
+			user_agent(userAgent, someArg, anotherArg)`,
 			in: `
 		{
 		   "userAgent" : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15"
@@ -109,10 +243,8 @@ func TestUserAgent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			runner, err := NewTestingRunner(tc.pl)
 			if err != nil {
-				if tc.fail {
-					t.Logf("[%d]expect error: %s", idx, err)
-				} else {
-					t.Errorf("[%d] failed: %s", idx, err)
+				if !tc.fail {
+					t.Fatalf("[%d] unexpected compile error: %s", idx, err)
 				}
 				return
 			}
@@ -122,19 +254,21 @@ func TestUserAgent(t *testing.T) {
 			errR := runScript(runner, pt)
 
 			if errR != nil {
-				if tc.fail {
-					t.Logf("[%d]expect error: %s", idx, err)
-				} else {
-					t.Fatal(errR)
+				if !tc.fail {
+					t.Fatalf("[%d] unexpected runtime error: %s", idx, errR)
 				}
-			} else {
-				fieldsToCompare := make(map[string]interface{})
-				for k := range tc.expected {
-					fieldsToCompare[k], _, _ = pt.Get(k)
-				}
-				tu.Equals(t, tc.expected, fieldsToCompare)
-				t.Logf("[%d] PASS", idx)
+				return
 			}
+			if tc.fail {
+				t.Fatal("expected an error, got nil")
+			}
+
+			fieldsToCompare := make(map[string]interface{})
+			for k := range tc.expected {
+				fieldsToCompare[k], _, _ = pt.Get(k)
+			}
+			tu.Equals(t, tc.expected, fieldsToCompare)
+			t.Logf("[%d] PASS", idx)
 		})
 	}
 }

--- a/ptinput/funcs/md/geoip.en.md
+++ b/ptinput/funcs/md/geoip.en.md
@@ -1,6 +1,6 @@
 ### `geoip()` {#fn-geoip}
 
-Function prototype: `fn geoip(ip: str)`
+Function prototype: `fn geoip(ip: str, prefix: str = "")`
 
 Function description: Append more IP information to IP. `geoip()` will generate additional fields, such as:
 
@@ -12,6 +12,7 @@ Function description: Append more IP information to IP. `geoip()` will generate 
 Function parameters:
 
 - `ip`: The extracted IP field supports both IPv4 and IPv6
+- `prefix`: Optional. Adds a custom prefix to the generated fields to avoid conflicts with existing fields. It can also be passed as a named parameter, e.g. `geoip(ip, prefix="geo_")`.
 
 Example:
 
@@ -30,5 +31,24 @@ geoip(ip)
   "province" : "Queensland",
   "isp"      : "unknown"
   "message"  : "{\"ip\": \"1.2.3.4\"}",
+}
+```
+
+Example with prefix:
+
+```python
+# input data: {"ip":"1.2.3.4"}
+
+# script
+json(_, ip)
+geoip(ip, "geo_")
+
+# result
+{
+  "geo_city"     : "Brisbane",
+  "geo_country"  : "AU",
+  "geo_province" : "Queensland",
+  "geo_isp"      : "unknown",
+  "ip"           : "1.2.3.4"
 }
 ```

--- a/ptinput/funcs/md/geoip.en.md
+++ b/ptinput/funcs/md/geoip.en.md
@@ -29,8 +29,8 @@ geoip(ip)
   "country"  : "AU",
   "ip"       : "1.2.3.4",
   "province" : "Queensland",
-  "isp"      : "unknown"
-  "message"  : "{\"ip\": \"1.2.3.4\"}",
+  "isp"      : "unknown",
+  "message"  : "{\"ip\": \"1.2.3.4\"}"
 }
 ```
 

--- a/ptinput/funcs/md/geoip.md
+++ b/ptinput/funcs/md/geoip.md
@@ -29,8 +29,8 @@ geoip(ip)
   "country"  : "AU",
   "ip"       : "1.2.3.4",
   "province" : "Queensland",
-  "isp"      : "unknown"
-  "message"  : "{\"ip\": \"1.2.3.4\"}",
+  "isp"      : "unknown",
+  "message"  : "{\"ip\": \"1.2.3.4\"}"
 }
 ```
 

--- a/ptinput/funcs/md/geoip.md
+++ b/ptinput/funcs/md/geoip.md
@@ -1,6 +1,6 @@
 ### `geoip()` {#fn-geoip}
 
-函数原型：`fn geoip(ip: str)`
+函数原型：`fn geoip(ip: str, prefix: str = "")`
 
 函数说明：在 IP 上追加更多 IP 信息。 `geoip()` 会额外产生多个字段，如：
 
@@ -12,6 +12,7 @@
 参数：
 
 - `ip`: 已经提取出来的 IP 字段，支持 IPv4 和 IPv6
+- `prefix`: 可选参数，为生成的字段添加自定义前缀，避免与已有字段产生冲突。支持以命名参数形式传入，如 `geoip(ip, prefix="geo_")`
 
 示例：
 
@@ -30,5 +31,24 @@ geoip(ip)
   "province" : "Queensland",
   "isp"      : "unknown"
   "message"  : "{\"ip\": \"1.2.3.4\"}",
+}
+```
+
+添加前缀示例：
+
+```python
+# 待处理数据：{"ip":"1.2.3.4"}
+
+# 处理脚本
+json(_, ip)
+geoip(ip, "geo_")
+
+# 处理结果
+{
+  "geo_city"     : "Brisbane",
+  "geo_country"  : "AU",
+  "geo_province" : "Queensland",
+  "geo_isp"      : "unknown",
+  "ip"           : "1.2.3.4"
 }
 ```

--- a/ptinput/funcs/md/http_request.en.md
+++ b/ptinput/funcs/md/http_request.en.md
@@ -1,6 +1,6 @@
 ### `http_request()` {#fn-http-request}
 
-Function prototype: `fn http_request(method: str, url: str, headers: map, body: any) map`
+Function prototype: `fn http_request(method: str, url: str, headers: map, body: any, prefix: str = "") map`
 
 Function description: Send an HTTP request, receive the response, and encapsulate it into a map
 
@@ -10,6 +10,7 @@ Function parameters:
 - `url`: Request path
 - `headers`: Additional header，the type is map[string]string
 - `body`: Request body
+- `prefix`: Optional. Adds a custom prefix to the fixed keys (`status_code`, `body`) of the returned map to avoid conflicts with existing fields. It can also be passed as a named parameter, e.g. `http_request(method, url, prefix="hr_")`.
 
 Return type: map
 
@@ -25,5 +26,15 @@ resp = http_request("GET", "http://localhost:8080/testResp")
 resp_body = load_json(resp["body"])
 
 add_key(abc, resp["status_code"])
+add_key(abc, resp_body["a"])
+```
+
+Example with prefix:
+
+```python
+resp = http_request("GET", "http://localhost:8080/testResp", {}, "", "hr_")
+resp_body = load_json(resp["hr_body"])
+
+add_key(abc, resp["hr_status_code"])
 add_key(abc, resp_body["a"])
 ```

--- a/ptinput/funcs/md/http_request.en.md
+++ b/ptinput/funcs/md/http_request.en.md
@@ -1,6 +1,6 @@
 ### `http_request()` {#fn-http-request}
 
-Function prototype: `fn http_request(method: str, url: str, headers: map, body: any, prefix: str = "") map`
+Function prototype: `fn http_request(method: str, url: str, headers: map = nil, body: any = nil, prefix: str = "") map`
 
 Function description: Send an HTTP request, receive the response, and encapsulate it into a map
 
@@ -8,8 +8,8 @@ Function parameters:
 
 - `method`: GET|POST
 - `url`: Request path
-- `headers`: Additional header，the type is map[string]string
-- `body`: Request body
+- `headers`: Optional. Additional headers of type map[string]string
+- `body`: Optional. Request body
 - `prefix`: Optional. Adds a custom prefix to the fixed keys (`status_code`, `body`) of the returned map to avoid conflicts with existing fields. It can also be passed as a named parameter, e.g. `http_request(method, url, prefix="hr_")`.
 
 Return type: map

--- a/ptinput/funcs/md/http_request.en.md
+++ b/ptinput/funcs/md/http_request.en.md
@@ -6,7 +6,7 @@ Function description: Send an HTTP request, receive the response, and encapsulat
 
 Function parameters:
 
-- `method`: GET|POST
+- `method`: HTTP request method, such as GET, POST, or PUT
 - `url`: Request path
 - `headers`: Optional. Additional headers of type map[string]string
 - `body`: Optional. Request body
@@ -32,7 +32,7 @@ add_key(abc, resp_body["a"])
 Example with prefix:
 
 ```python
-resp = http_request("GET", "http://localhost:8080/testResp", {}, "", "hr_")
+resp = http_request("GET", "http://localhost:8080/testResp", prefix="hr_")
 resp_body = load_json(resp["hr_body"])
 
 add_key(abc, resp["hr_status_code"])

--- a/ptinput/funcs/md/http_request.md
+++ b/ptinput/funcs/md/http_request.md
@@ -6,7 +6,7 @@
 
 参数：
 
-- `method`：GET|POST
+- `method`：HTTP 请求方法，如 GET、POST、PUT
 - `url`: 请求路径
 - `headers`：可选参数，附加的 header，类型为 map[string]string
 - `body`：可选参数，请求体
@@ -32,7 +32,7 @@ add_key(abc, resp_body["a"])
 添加前缀示例：
 
 ```python
-resp = http_request("GET", "http://localhost:8080/testResp", {}, "", "hr_")
+resp = http_request("GET", "http://localhost:8080/testResp", prefix="hr_")
 resp_body = load_json(resp["hr_body"])
 
 add_key(abc, resp["hr_status_code"])

--- a/ptinput/funcs/md/http_request.md
+++ b/ptinput/funcs/md/http_request.md
@@ -1,6 +1,6 @@
 ### `http_request()` {#fn-http-request}
 
-函数原型： `fn http_request(method: str, url: str, headers: map, body: any, prefix: str = "") map`
+函数原型： `fn http_request(method: str, url: str, headers: map = nil, body: any = nil, prefix: str = "") map`
 
 函数说明： 发送 HTTP 请求，接收响应并封装成 map
 
@@ -8,8 +8,8 @@
 
 - `method`：GET|POST
 - `url`: 请求路径
-- `headers`：附加的 header，类型为 map[string]string
-- `body`：请求体
+- `headers`：可选参数，附加的 header，类型为 map[string]string
+- `body`：可选参数，请求体
 - `prefix`：可选参数，为返回 map 中固定的 key（`status_code`、`body`）添加自定义前缀，避免与已有字段产生冲突。支持以命名参数形式传入，如 `http_request(method, url, prefix="hr_")`
 
 返回值类型：map

--- a/ptinput/funcs/md/http_request.md
+++ b/ptinput/funcs/md/http_request.md
@@ -1,6 +1,6 @@
 ### `http_request()` {#fn-http-request}
 
-函数原型： `fn http_request(method: str, url: str, headers: map, body: any) map`
+函数原型： `fn http_request(method: str, url: str, headers: map, body: any, prefix: str = "") map`
 
 函数说明： 发送 HTTP 请求，接收响应并封装成 map
 
@@ -10,6 +10,7 @@
 - `url`: 请求路径
 - `headers`：附加的 header，类型为 map[string]string
 - `body`：请求体
+- `prefix`：可选参数，为返回 map 中固定的 key（`status_code`、`body`）添加自定义前缀，避免与已有字段产生冲突。支持以命名参数形式传入，如 `http_request(method, url, prefix="hr_")`
 
 返回值类型：map
 
@@ -25,5 +26,15 @@ resp = http_request("GET", "http://localhost:8080/testResp")
 resp_body = load_json(resp["body"])
 
 add_key(abc, resp["status_code"])
+add_key(abc, resp_body["a"])
+```
+
+添加前缀示例：
+
+```python
+resp = http_request("GET", "http://localhost:8080/testResp", {}, "", "hr_")
+resp_body = load_json(resp["hr_body"])
+
+add_key(abc, resp["hr_status_code"])
 add_key(abc, resp_body["a"])
 ```

--- a/ptinput/funcs/md/lowercase.en.md
+++ b/ptinput/funcs/md/lowercase.en.md
@@ -14,7 +14,8 @@ Example:
 # input data: {"first": "HeLLo","second":2,"third":"aBC","forth":true}
 
 # script
-json(_, first) lowercase(first)
+json(_, first)
+lowercase(first)
 
 # result
 {

--- a/ptinput/funcs/md/lowercase.md
+++ b/ptinput/funcs/md/lowercase.md
@@ -14,7 +14,8 @@
 # 待处理数据：{"first": "HeLLo","second":2,"third":"aBC","forth":true}
 
 # 处理脚本
-json(_, first) lowercase(first)
+json(_, first)
+lowercase(first)
 
 # 处理结果
 {

--- a/ptinput/funcs/md/nullif.en.md
+++ b/ptinput/funcs/md/nullif.en.md
@@ -16,7 +16,9 @@ Example:
 # input data: {"first": 1,"second":2,"third":"aBC","forth":true}
 
 # script
-json(_, first) json(_, second) nullif(first, "1")
+json(_, first)
+json(_, second)
+nullif(first, "1")
 
 # result
 {

--- a/ptinput/funcs/md/nullif.md
+++ b/ptinput/funcs/md/nullif.md
@@ -15,7 +15,9 @@
 # 待处理数据：{"first": 1,"second":2,"third":"aBC","forth":true}
 
 # 处理脚本
-json(_, first) json(_, second) nullif(first, "1")
+json(_, first)
+json(_, second)
+nullif(first, "1")
 
 # 处理结果
 {

--- a/ptinput/funcs/md/uppercase.en.md
+++ b/ptinput/funcs/md/uppercase.en.md
@@ -14,7 +14,8 @@ Example:
 # Data to be processed: {"first": "hello","second":2,"third":"aBC","forth":true}
 
 # process script
-json(_, first) uppercase(first)
+json(_, first)
+uppercase(first)
 
 # process result
 {

--- a/ptinput/funcs/md/uppercase.md
+++ b/ptinput/funcs/md/uppercase.md
@@ -14,7 +14,8 @@
 # 待处理数据：{"first": "hello","second":2,"third":"aBC","forth":true}
 
 # 处理脚本
-json(_, first) uppercase(first)
+json(_, first)
+uppercase(first)
 
 # 处理结果
 {

--- a/ptinput/funcs/md/url_decode.en.md
+++ b/ptinput/funcs/md/url_decode.en.md
@@ -14,7 +14,8 @@ Example:
 # Data to be processed: {"url":"http%3a%2f%2fwww.baidu.com%2fs%3fwd%3d%e6%b5%8b%e8%af%95"}
 
 # process script
-json(_, url) url_decode(url)
+json(_, url)
+url_decode(url)
 
 # process result
 {

--- a/ptinput/funcs/md/url_decode.md
+++ b/ptinput/funcs/md/url_decode.md
@@ -14,7 +14,8 @@
 # 待处理数据：{"url":"http%3a%2f%2fwww.baidu.com%2fs%3fwd%3d%e6%b5%8b%e8%af%95"}
 
 # 处理脚本
-json(_, url) url_decode(url)
+json(_, url)
+url_decode(url)
 
 # 处理结果
 {

--- a/ptinput/funcs/md/url_parse.en.md
+++ b/ptinput/funcs/md/url_parse.en.md
@@ -1,12 +1,13 @@
 ### `url_parse()` {#fn-url-parse}
 
-Function prototype: `fn url_parse(key)`
+Function prototype: `fn url_parse(key, prefix: str = "")`
 
 Function description: parse the url whose field name is key.
 
 Function parameters:
 
 - `key`: field name of the url to parse.
+- `prefix`: Optional. Adds a custom prefix to the fixed keys (`scheme`, `host`, `port`, `path`, `params`) of the returned map to avoid conflicts with existing fields. It can also be passed as a named parameter, e.g. `url_parse(url, prefix="up_")`.
 
 Example:
 
@@ -22,6 +23,25 @@ add_key(scheme, m["scheme"])
 {
      "url": "https://www.baidu.com",
      "scheme": "https"
+}
+```
+
+Example with prefix:
+
+```python
+# Data to be processed: {"url": "https://www.baidu.com"}
+
+# process script
+json(_, url)
+m = url_parse(url, "up_")
+add_key(scheme, m["up_scheme"])
+add_key(h, m["up_host"])
+
+# process result
+{
+     "url": "https://www.baidu.com",
+     "scheme": "https",
+     "h": "www.baidu.com"
 }
 ```
 

--- a/ptinput/funcs/md/url_parse.md
+++ b/ptinput/funcs/md/url_parse.md
@@ -1,12 +1,13 @@
 ### `url_parse()` {#fn-url-parse}
 
-函数原型：`fn url_parse(key)`
+函数原型：`fn url_parse(key, prefix: str = "")`
 
 函数说明：解析字段名称为 key 的 url。
 
 函数参数
 
 - `key`: 要解析的 url 的字段名称。
+- `prefix`: 可选参数，为返回 map 中固定的 key（`scheme`、`host`、`port`、`path`、`params`）添加自定义前缀，避免与已有字段产生冲突。支持以命名参数形式传入，如 `url_parse(url, prefix="up_")`
 
 示例：
 
@@ -22,6 +23,25 @@ add_key(scheme, m["scheme"])
 {
     "url": "https://www.baidu.com",
     "scheme": "https"
+}
+```
+
+添加前缀示例：
+
+```python
+# 待处理数据：{"url": "https://www.baidu.com"}
+
+# 处理脚本
+json(_, url)
+m = url_parse(url, "up_")
+add_key(scheme, m["up_scheme"])
+add_key(h, m["up_host"])
+
+# 处理结果
+{
+    "url": "https://www.baidu.com",
+    "scheme": "https",
+    "h": "www.baidu.com"
 }
 ```
 

--- a/ptinput/funcs/md/user_agent.en.md
+++ b/ptinput/funcs/md/user_agent.en.md
@@ -1,12 +1,13 @@
 ### `user_agent()` {#fn-user-agent}
 
-Function prototype: `fn user_agent(key: str)`
+Function prototype: `fn user_agent(key: str, prefix: str = "")`
 
 Function description: Obtain client information on the specified field
 
 Function parameters:
 
 - `key`: the field to be extracted
+- `prefix`: Optional. Adds a custom prefix to the generated fields to avoid conflicts with existing fields. It can also be passed as a named parameter, e.g. `user_agent(userAgent, prefix="ua_")`.
 
 `user_agent()` will generate multiple fields, such as:
 
@@ -24,5 +25,14 @@ Example:
 # "forth" : true
 # }
 
-json(_, userAgent) user_agent(userAgent)
+json(_, userAgent)
+user_agent(userAgent)
+```
+
+Example with prefix:
+
+```python
+json(_, userAgent)
+user_agent(userAgent, "ua_")
+# Generated fields are ua_isMobile, ua_os, ua_browser, etc.
 ```

--- a/ptinput/funcs/md/user_agent.md
+++ b/ptinput/funcs/md/user_agent.md
@@ -1,12 +1,13 @@
 ### `user_agent()` {#fn-user-agent}
 
-函数原型：`fn user_agent(key: str)`
+函数原型：`fn user_agent(key: str, prefix: str = "")`
 
 函数说明：对指定字段上获取客户端信息
 
 函数参数
 
 - `key`: 待提取字段
+- `prefix`: 可选参数，为生成的字段添加自定义前缀，避免与已有字段产生冲突。支持以命名参数形式传入，如 `user_agent(userAgent, prefix="ua_")`
 
 `user_agent()` 会生产多个字段，如：
 
@@ -24,5 +25,14 @@
 #        "forth"     : true
 #    }
 
-json(_, userAgent) user_agent(userAgent)
+json(_, userAgent)
+user_agent(userAgent)
+```
+
+添加前缀示例：
+
+```python
+json(_, userAgent)
+user_agent(userAgent, "ua_")
+# 生成的字段为 ua_isMobile、ua_os、ua_browser 等
 ```


### PR DESCRIPTION
## Summary

- add an optional `prefix` parameter to `geoip`, `user_agent`, `url_parse`, and `http_request`
- support positional, named, and string-variable prefix arguments while preserving existing calls when the prefix is omitted
- prevent prefixed output from overwriting existing unprefixed fields
- update Chinese and English function documentation and strengthen compatibility/error-path tests

## Impact

Existing pipeline scripts remain compatible because every new `prefix` parameter defaults to an empty string. Callers can opt in to namespaced output fields to avoid collisions.

## Validation

- `go test ./ptinput/funcs -run '^(TestGeoIpFunc|TestHTTPRequest|TestURLParse|TestUserAgent)$' -count=50`
- `go test ./ptinput/funcs -skip '^TestGrokRunObserver$' -count=1`
- `go test ./internal/command/arbitercheck -skip '^TestRunChecksDQL$' -count=1`
- `go test ./pkg/arbiter/request -skip '^TestHostFilte$' -count=1`
- `go vet ./...`
- `git diff --check`

A full `go test ./...` run still reports three environment-dependent failures that reproduce unchanged on `origin/main`: a missing `dqlcheck` helper executable, host-filter DNS differences, and a Windows timer-resolution assertion in `TestGrokRunObserver`.

Race testing was attempted with CGO and the available LLVM toolchain, but the local Windows linker could not link the race-enabled test binary.
